### PR TITLE
feat(drive): add fullText search and recursive folder filtering to `drive_files_search`

### DIFF
--- a/drive/client.go
+++ b/drive/client.go
@@ -93,8 +93,14 @@ func (c *Client) ListFiles(query string, pageSize int64, parentID string) ([]*dr
 	return fileList.Files, nil
 }
 
+// SearchOptions holds optional parameters for SearchFiles.
+type SearchOptions struct {
+	FullText string
+	FolderID string // If set, results are filtered client-side to files within this folder (recursive)
+}
+
 // SearchFiles searches for files
-func (c *Client) SearchFiles(name, mimeType string, modifiedAfter string) ([]*drive.File, error) {
+func (c *Client) SearchFiles(name, mimeType, modifiedAfter string, opts SearchOptions) ([]*drive.File, error) {
 	query := ""
 	if name != "" {
 		query = fmt.Sprintf("name contains '%s'", name)
@@ -111,8 +117,58 @@ func (c *Client) SearchFiles(name, mimeType string, modifiedAfter string) ([]*dr
 		}
 		query += fmt.Sprintf("modifiedTime > '%s'", modifiedAfter)
 	}
+	if opts.FullText != "" {
+		if query != "" {
+			query += " and "
+		}
+		query += fmt.Sprintf("fullText contains '%s'", opts.FullText)
+	}
 
-	return c.ListFiles(query, 100, "")
+	files, err := c.ListFiles(query, 100, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.FolderID != "" {
+		cache := make(map[string]bool)
+		filtered := files[:0]
+		for _, f := range files {
+			if c.isDescendantOf(f.Parents, opts.FolderID, cache) {
+				filtered = append(filtered, f)
+			}
+		}
+		files = filtered
+	}
+
+	return files, nil
+}
+
+// isDescendantOf checks whether a file (identified by its direct parents) is inside targetFolderID,
+// walking up the folder tree recursively. cache maps folder IDs to their result to avoid redundant API calls.
+func (c *Client) isDescendantOf(parents []string, targetFolderID string, cache map[string]bool) bool {
+	for _, parentID := range parents {
+		if parentID == targetFolderID {
+			return true
+		}
+		if cached, ok := cache[parentID]; ok {
+			if cached {
+				return true
+			}
+			continue
+		}
+		// Mark false first to handle any cycles
+		cache[parentID] = false
+		parent, err := c.GetFile(parentID)
+		if err != nil || len(parent.Parents) == 0 {
+			continue
+		}
+		result := c.isDescendantOf(parent.Parents, targetFolderID, cache)
+		cache[parentID] = result
+		if result {
+			return true
+		}
+	}
+	return false
 }
 
 // GetFile gets file metadata

--- a/drive/client_test.go
+++ b/drive/client_test.go
@@ -564,6 +564,108 @@ func TestConvertMarkdownToHTML_Styles(t *testing.T) {
 	}
 }
 
+// captureTransport records the last request URL for query inspection.
+type captureTransport struct {
+	lastRequest *http.Request
+}
+
+func (t *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.lastRequest = req
+	body := `{"files": []}`
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}, nil
+}
+
+func newClientWithCapture(t *testing.T) (*Client, *captureTransport) {
+	t.Helper()
+	ct := &captureTransport{}
+	httpClient := &http.Client{Transport: ct}
+	service, err := drive.NewService(context.Background(), option.WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("Failed to create Drive service: %v", err)
+	}
+	return &Client{service: service}, ct
+}
+
+func TestSearchFiles_FullText(t *testing.T) {
+	client, ct := newClientWithCapture(t)
+
+	_, err := client.SearchFiles("", "", "", SearchOptions{FullText: "buttercup"})
+	if err != nil {
+		t.Fatalf("SearchFiles() error = %v", err)
+	}
+
+	q := ct.lastRequest.URL.Query().Get("q")
+	if !strings.Contains(q, "fullText contains 'buttercup'") {
+		t.Errorf("expected q to contain fullText clause, got: %q", q)
+	}
+}
+
+func TestSearchFiles_FolderID_NotInQuery(t *testing.T) {
+	client, ct := newClientWithCapture(t)
+
+	_, err := client.SearchFiles("", "", "", SearchOptions{FullText: "buttercup", FolderID: "folder123"})
+	if err != nil {
+		t.Fatalf("SearchFiles() error = %v", err)
+	}
+
+	q := ct.lastRequest.URL.Query().Get("q")
+	if !strings.Contains(q, "fullText contains 'buttercup'") {
+		t.Errorf("expected q to contain fullText clause, got: %q", q)
+	}
+	// FolderID filtering is client-side; folder ID must NOT appear in the Drive API query
+	if strings.Contains(q, "folder123") {
+		t.Errorf("folder ID should be absent from API query (filtering is client-side), got: %q", q)
+	}
+}
+
+func TestSearchFiles_AllParams(t *testing.T) {
+	client, ct := newClientWithCapture(t)
+
+	_, err := client.SearchFiles("budget", "text/markdown", "2025-01-01T00:00:00Z", SearchOptions{FullText: "tax", FolderID: "folder789"})
+	if err != nil {
+		t.Fatalf("SearchFiles() error = %v", err)
+	}
+
+	q := ct.lastRequest.URL.Query().Get("q")
+	for _, want := range []string{
+		"name contains 'budget'",
+		"mimeType = 'text/markdown'",
+		"modifiedTime > '2025-01-01T00:00:00Z'",
+		"fullText contains 'tax'",
+	} {
+		if !strings.Contains(q, want) {
+			t.Errorf("expected q to contain %q, got: %q", want, q)
+		}
+	}
+	if strings.Contains(q, "folder789") {
+		t.Errorf("folder ID should be absent from API query (filtering is client-side), got: %q", q)
+	}
+}
+
+func TestSearchFiles_NoOpts_BackwardCompat(t *testing.T) {
+	client, ct := newClientWithCapture(t)
+
+	_, err := client.SearchFiles("report", "", "", SearchOptions{})
+	if err != nil {
+		t.Fatalf("SearchFiles() error = %v", err)
+	}
+
+	q := ct.lastRequest.URL.Query().Get("q")
+	if !strings.Contains(q, "name contains 'report'") {
+		t.Errorf("expected q to contain name clause, got: %q", q)
+	}
+	if strings.Contains(q, "fullText") {
+		t.Errorf("expected no fullText clause when FullText is empty, got: %q", q)
+	}
+	if strings.Contains(q, "in parents") {
+		t.Errorf("expected no parent clause when FolderID is empty, got: %q", q)
+	}
+}
+
 func BenchmarkConvertMarkdownToHTML(b *testing.B) {
 	markdown := `# Benchmark Document
 

--- a/drive/tools.go
+++ b/drive/tools.go
@@ -59,6 +59,14 @@ func (h *Handler) GetTools() []server.Tool {
 						Type:        "string",
 						Description: "Modified after date (RFC3339 format)",
 					},
+					"full_text": {
+						Type:        "string",
+						Description: "Full-text search query (searches file contents)",
+					},
+					"folder_id": {
+						Type:        "string",
+						Description: "Restrict results to files inside this folder (recursive); filtering is done client-side after a global fullText search",
+					},
 				},
 			},
 		},
@@ -369,11 +377,13 @@ func (h *Handler) HandleToolCall(ctx context.Context, name string, arguments jso
 			Name          string `json:"name"`
 			MimeType      string `json:"mime_type"`
 			ModifiedAfter string `json:"modified_after"`
+			FullText      string `json:"full_text"`
+			FolderID      string `json:"folder_id"`
 		}
 		if err := json.Unmarshal(arguments, &args); err != nil {
 			return nil, fmt.Errorf("invalid arguments: %w", err)
 		}
-		return h.handleFilesSearch(ctx, args.Name, args.MimeType, args.ModifiedAfter)
+		return h.handleFilesSearch(ctx, args.Name, args.MimeType, args.ModifiedAfter, args.FullText, args.FolderID)
 
 	case "drive_file_download":
 		var args struct {
@@ -555,8 +565,8 @@ func (h *Handler) handleFilesList(ctx context.Context, parentID string, pageSize
 	}, nil
 }
 
-func (h *Handler) handleFilesSearch(ctx context.Context, name, mimeType, modifiedAfter string) (interface{}, error) {
-	files, err := h.client.SearchFiles(name, mimeType, modifiedAfter)
+func (h *Handler) handleFilesSearch(ctx context.Context, name, mimeType, modifiedAfter, fullText, folderID string) (interface{}, error) {
+	files, err := h.client.SearchFiles(name, mimeType, modifiedAfter, SearchOptions{FullText: fullText, FolderID: folderID})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds two new parameters to the `drive_files_search` tool:

- `full_text`: searches file contents via the Drive API `fullText contains` operator (versus just filename)
- `folder_id`: restricts results to files inside the given folder, including all subfolders

### Notes on `folder_id` param

The `folder_id` parameter required a client-side filtering approach. The Drive API `parents` field on a file only exposes its direct parent — not the full ancestor chain. When combined with `fullText contains`, the `in parents` operator only matches direct children of a folder, making it useless for deeply nested structures like UpNote backup folders. The `in ancestors` operator returns a 400 Invalid Value error from the API.

The solution is to run the `fullText` search globally, then for each result walk up the parent chain via `GetFile` calls until reaching either the target folder (include) or the root (exclude). A cache keyed by folder ID avoids redundant API calls when multiple results share common ancestors.