### PR TITLE
fix(server): MCP protocol compliance for strict clients (Claude Code)

### DIFF
--- a/server/mcp.go
+++ b/server/mcp.go
@@ -163,27 +163,62 @@ type Handler struct {
 }
 
 func (h *Handler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	// Notifications (no id) must not receive a response per JSON-RPC 2.0.
+	// Replying to notifications confuses strict clients like Claude Code.
+	if req.Notif {
+		return
+	}
+
 	switch req.Method {
 	case "initialize":
 		h.handleInitialize(ctx, conn, req)
-	case "initialized":
-		// Client confirms initialization
+	case "notifications/initialized", "initialized":
+		// Client confirms initialization. Tolerate both spellings.
 	case "tools/list":
 		h.handleToolsList(ctx, conn, req)
 	case "tools/call":
 		h.handleToolCall(ctx, conn, req)
 	case "resources/list":
 		h.handleResourcesList(ctx, conn, req)
+	case "resources/templates/list":
+		h.handleResourceTemplatesList(ctx, conn, req)
 	case "resources/read":
 		h.handleResourceRead(ctx, conn, req)
+	case "prompts/list":
+		h.handlePromptsList(ctx, conn, req)
 	case "completion/complete":
 		h.handleCompletion(ctx, conn, req)
+	case "ping":
+		_ = conn.Reply(ctx, req.ID, struct{}{})
 	default:
 		_ = conn.ReplyWithError(ctx, req.ID, &jsonrpc2.Error{
 			Code:    jsonrpc2.CodeMethodNotFound,
 			Message: fmt.Sprintf("method not found: %s", req.Method),
 		})
 	}
+}
+
+// handleResourceTemplatesList returns an empty list of resource templates.
+// MCP clients probe for this during initialization; without a handler, the
+// default method-not-found error can destabilize strict clients.
+func (h *Handler) handleResourceTemplatesList(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	response := struct {
+		ResourceTemplates []Resource `json:"resourceTemplates"`
+	}{
+		ResourceTemplates: []Resource{},
+	}
+	_ = conn.Reply(ctx, req.ID, response)
+}
+
+// handlePromptsList returns an empty prompts list. This server exposes no
+// prompts, but clients expect a valid response rather than an error.
+func (h *Handler) handlePromptsList(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	response := struct {
+		Prompts []struct{} `json:"prompts"`
+	}{
+		Prompts: []struct{}{},
+	}
+	_ = conn.Reply(ctx, req.ID, response)
 }
 
 func (h *Handler) handleInitialize(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {


### PR DESCRIPTION
## Summary

Three related protocol bugs prevented this server from holding an MCP stdio connection with strict clients (verified with Claude Code on macOS). The stdio transport dropped ~15 seconds after handshake with:

```
Connection error: Received a response for an unknown message ID:
{"jsonrpc":"2.0","id":0,"error":{"code":-32601,"message":"method not found: notifications/initialized"}}
```

## Root cause

The `Handle` method in `server/mcp.go` had three issues, all reproducible against a vanilla `v0.4.0` Homebrew install:

1. **Notifications received error responses.** JSON-RPC 2.0 notifications (no id) must not receive a response. The server was falling through to the `default` case and replying with `-32601`. Clients that track message IDs (like Claude Code) treated the reply as a response to an unknown message ID and closed the transport.

2. **`notifications/initialized` was not matched.** Only the legacy spelling `initialized` was in the switch; the current MCP spec spelling `notifications/initialized` fell through to `default` and triggered the error reply above.

3. **`resources/templates/list` and `prompts/list` were not handled.** Clients probe these during initialization. `method not found` replies are tolerated by lenient clients, but some strict clients abort init on an unexpected error. Both now return empty arrays.

## Fix

- Return early on `req.Notif` — notifications are silently accepted
- Match both `notifications/initialized` and the legacy `initialized`
- Add `resources/templates/list` handler returning `{ resourceTemplates: [] }`
- Add `prompts/list` handler returning `{ prompts: [] }`
- Add a `ping` handler (used by some clients for keepalive)

## Test plan

- [x] `go test ./server/...` passes
- [x] Manual replay of Claude Code's initialization sequence — `initialize` responds correctly, `notifications/initialized` silently accepted (no response written), `resources/templates/list` and `prompts/list` return empty lists, `tools/list` returns all 31 tools, connection remains open
- [x] Real Claude Code stdio connection held through a full session — `mcp__google_personal__calendar_events_list`, `mcp__google_personal__gmail_messages_list`, and `mcp__google_personal__drive_files_list` all work

## Scope

Server protocol only. No changes to account management, OAuth, service registration, or any Google API interaction. All existing tests pass unchanged.