### PR TITLE
feat: Claude Code compatibility + Gmail multipart bodies and attachment downloads

### DIFF
--- a/gmail/client.go
+++ b/gmail/client.go
@@ -51,3 +51,13 @@ func (c *Client) GetMessage(messageID string) (*gmail.Message, error) {
 	}
 	return message, nil
 }
+
+// GetAttachment fetches the binary body of a message attachment. The returned
+// Data is base64url-encoded per the Gmail API MessagePartBody contract.
+func (c *Client) GetAttachment(messageID, attachmentID string) (*gmail.MessagePartBody, error) {
+	att, err := c.service.Users.Messages.Attachments.Get("me", messageID, attachmentID).Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get attachment: %w", err)
+	}
+	return att, nil
+}

--- a/gmail/multi_account.go
+++ b/gmail/multi_account.go
@@ -2,6 +2,7 @@ package gmail
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -204,6 +205,28 @@ func (h *MultiAccountHandler) GetTools() []server.Tool {
 			},
 		},
 		{
+			Name:        "gmail_attachment_get",
+			Description: "Download an attachment from a Gmail message. Returns the attachment's base64url-encoded data plus filename and mime type. Attachment IDs come from gmail_message_get's 'attachments' list.",
+			InputSchema: server.InputSchema{
+				Type: "object",
+				Properties: map[string]server.Property{
+					"message_id": {
+						Type:        "string",
+						Description: "Message ID",
+					},
+					"attachment_id": {
+						Type:        "string",
+						Description: "Attachment ID (from gmail_message_get response)",
+					},
+					"account": {
+						Type:        "string",
+						Description: "Email address of the account to use (optional)",
+					},
+				},
+				Required: []string{"message_id", "attachment_id"},
+			},
+		},
+		{
 			Name:        "gmail_messages_list_all_accounts",
 			Description: "List messages from all authenticated accounts",
 			InputSchema: server.InputSchema{
@@ -221,6 +244,76 @@ func (h *MultiAccountHandler) GetTools() []server.Tool {
 			},
 		},
 	}
+}
+
+// extractBodyAndAttachments walks a message payload (including nested
+// multipart parts) to produce:
+//   - bodyText: the text/plain body if present
+//   - bodyHTML: the text/html body if present
+//   - attachments: metadata for every part with a Filename and an AttachmentId
+//
+// Bodies are base64url-decoded for convenience. Attachment bodies are NOT
+// fetched here — callers use gmail_attachment_get with the returned IDs.
+func extractBodyAndAttachments(part *gmail.MessagePart) (bodyText, bodyHTML string, attachments []map[string]interface{}) {
+	if part == nil {
+		return
+	}
+
+	decode := func(data string) string {
+		if data == "" {
+			return ""
+		}
+		raw, err := base64URLDecode(data)
+		if err != nil {
+			return ""
+		}
+		return string(raw)
+	}
+
+	// Leaf part: either a body or an attachment.
+	if len(part.Parts) == 0 {
+		if part.Filename != "" && part.Body != nil && part.Body.AttachmentId != "" {
+			attachments = append(attachments, map[string]interface{}{
+				"attachment_id": part.Body.AttachmentId,
+				"filename":      part.Filename,
+				"mime_type":     part.MimeType,
+				"size":          part.Body.Size,
+			})
+			return
+		}
+		if part.Body != nil && part.Body.Data != "" {
+			switch part.MimeType {
+			case "text/plain":
+				bodyText = decode(part.Body.Data)
+			case "text/html":
+				bodyHTML = decode(part.Body.Data)
+			}
+		}
+		return
+	}
+
+	// Multipart: recurse, merging bodies and attachments.
+	for _, child := range part.Parts {
+		t, h, atts := extractBodyAndAttachments(child)
+		if bodyText == "" && t != "" {
+			bodyText = t
+		}
+		if bodyHTML == "" && h != "" {
+			bodyHTML = h
+		}
+		attachments = append(attachments, atts...)
+	}
+	return
+}
+
+// base64URLDecode decodes Gmail's base64url-encoded payload data. Gmail omits
+// padding and uses the URL-safe alphabet per RFC 4648 §5.
+func base64URLDecode(s string) ([]byte, error) {
+	// Restore padding
+	if m := len(s) % 4; m != 0 {
+		s += strings.Repeat("=", 4-m)
+	}
+	return base64.URLEncoding.DecodeString(s)
 }
 
 // HandleToolCall handles a tool call for Gmail service with multi-account support
@@ -304,21 +397,66 @@ func (h *MultiAccountHandler) HandleToolCall(ctx context.Context, name string, a
 			"account":      accountUsed,
 		}
 
-		// Extract headers for easier access
-		if message.Payload != nil && message.Payload.Headers != nil {
-			headers := make(map[string]string)
-			for _, header := range message.Payload.Headers {
-				headers[header.Name] = header.Value
+		if message.Payload != nil {
+			if message.Payload.Headers != nil {
+				headers := make(map[string]string)
+				for _, header := range message.Payload.Headers {
+					headers[header.Name] = header.Value
+				}
+				result["headers"] = headers
 			}
-			result["headers"] = headers
 
-			// Add body if available
-			if message.Payload.Body != nil && message.Payload.Body.Data != "" {
-				result["body"] = message.Payload.Body.Data
+			// Walk the payload tree to produce decoded bodies and a flat list
+			// of attachment metadata. Attachment bodies are fetched separately
+			// via gmail_attachment_get using the returned attachment_id values.
+			bodyText, bodyHTML, attachments := extractBodyAndAttachments(message.Payload)
+			if bodyText != "" {
+				result["body_text"] = bodyText
+			}
+			if bodyHTML != "" {
+				result["body_html"] = bodyHTML
+			}
+			if len(attachments) > 0 {
+				result["attachments"] = attachments
 			}
 		}
 
 		return result, nil
+
+	case "gmail_attachment_get":
+		var args struct {
+			MessageID    string `json:"message_id"`
+			AttachmentID string `json:"attachment_id"`
+			Account      string `json:"account"`
+		}
+		if err := json.Unmarshal(arguments, &args); err != nil {
+			return nil, fmt.Errorf("invalid arguments: %w", err)
+		}
+
+		client, accountUsed, err := h.multiClient.GetClientForContext(ctx, args.Account)
+		if err != nil {
+			if h.client != nil {
+				client = h.client
+				accountUsed = "default"
+			} else {
+				return nil, err
+			}
+		}
+
+		att, err := client.GetAttachment(args.MessageID, args.AttachmentID)
+		if err != nil {
+			return nil, err
+		}
+
+		return map[string]interface{}{
+			"account":       accountUsed,
+			"message_id":    args.MessageID,
+			"attachment_id": args.AttachmentID,
+			"size":          att.Size,
+			// Data is base64url-encoded per Gmail API. Consumers decode and
+			// write to disk or upload to Drive.
+			"data": att.Data,
+		}, nil
 
 	case "gmail_messages_list_all_accounts":
 		var args struct {

--- a/server/mcp.go
+++ b/server/mcp.go
@@ -163,27 +163,62 @@ type Handler struct {
 }
 
 func (h *Handler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	// Notifications (no id) must not receive a response per JSON-RPC 2.0.
+	// Replying to notifications confuses strict clients like Claude Code.
+	if req.Notif {
+		return
+	}
+
 	switch req.Method {
 	case "initialize":
 		h.handleInitialize(ctx, conn, req)
-	case "initialized":
-		// Client confirms initialization
+	case "notifications/initialized", "initialized":
+		// Client confirms initialization. Tolerate both spellings.
 	case "tools/list":
 		h.handleToolsList(ctx, conn, req)
 	case "tools/call":
 		h.handleToolCall(ctx, conn, req)
 	case "resources/list":
 		h.handleResourcesList(ctx, conn, req)
+	case "resources/templates/list":
+		h.handleResourceTemplatesList(ctx, conn, req)
 	case "resources/read":
 		h.handleResourceRead(ctx, conn, req)
+	case "prompts/list":
+		h.handlePromptsList(ctx, conn, req)
 	case "completion/complete":
 		h.handleCompletion(ctx, conn, req)
+	case "ping":
+		_ = conn.Reply(ctx, req.ID, struct{}{})
 	default:
 		_ = conn.ReplyWithError(ctx, req.ID, &jsonrpc2.Error{
 			Code:    jsonrpc2.CodeMethodNotFound,
 			Message: fmt.Sprintf("method not found: %s", req.Method),
 		})
 	}
+}
+
+// handleResourceTemplatesList returns an empty list of resource templates.
+// MCP clients probe for this during initialization; without a handler, the
+// default method-not-found error can destabilize strict clients.
+func (h *Handler) handleResourceTemplatesList(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	response := struct {
+		ResourceTemplates []Resource `json:"resourceTemplates"`
+	}{
+		ResourceTemplates: []Resource{},
+	}
+	_ = conn.Reply(ctx, req.ID, response)
+}
+
+// handlePromptsList returns an empty prompts list. This server exposes no
+// prompts, but clients expect a valid response rather than an error.
+func (h *Handler) handlePromptsList(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	response := struct {
+		Prompts []struct{} `json:"prompts"`
+	}{
+		Prompts: []struct{}{},
+	}
+	_ = conn.Reply(ctx, req.ID, response)
 }
 
 func (h *Handler) handleInitialize(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {


### PR DESCRIPTION
Two related improvements that together unblock using this MCP from Claude Code (and similar strict MCP clients) for real email workflows. Supersedes #10, which covered only the first commit.

## Commit 1 — `fix(server): MCP protocol compliance for strict clients (Claude Code)`

Three related protocol bugs caused Claude Code's MCP stdio client to drop the connection ~15 seconds after handshake:

```
Connection error: Received a response for an unknown message ID:
{\"jsonrpc\":\"2.0\",\"id\":0,\"error\":{\"code\":-32601,\"message\":\"method not found: notifications/initialized\"}}
```

### Root cause
In `server/mcp.go`'s `Handle` method (reproducible on vanilla `v0.4.0` Homebrew install):

1. **Notifications received error responses.** Per JSON-RPC 2.0, notifications (no `id`) must not receive a response. The server was falling through to the `default` case and replying with `-32601`. Strict clients tracking message IDs treated the reply as a response to an unknown ID and closed the transport.
2. **`notifications/initialized` was unmatched.** Only the legacy spelling `initialized` was in the switch; the current MCP spec spelling `notifications/initialized` fell through to `default` and triggered #1.
3. **`resources/templates/list` and `prompts/list` were unhandled.** Clients probe these during init. Method-not-found is tolerated by lenient clients but can abort init on strict ones.

### Fix
- Return early on `req.Notif` — notifications silently accepted
- Match both `notifications/initialized` and the legacy `initialized`
- Add `resources/templates/list` returning `{ resourceTemplates: [] }`
- Add `prompts/list` returning `{ prompts: [] }`
- Add a `ping` handler (used by some clients as keepalive)

Verified: stdio connection remains stable through a full Claude Code session; all 31 tools register correctly.

## Commit 2 — `feat(gmail): expose multipart bodies and attachment downloads`

`gmail_message_get` previously returned only the top-level payload body, which is empty for any `multipart/*` message (i.e. essentially all real Gmail). It also ignored `Payload.Parts` entirely, so attachments were invisible through the MCP.

### Changes
- **`gmail_message_get`** walks `Payload.Parts` recursively and adds three fields to the response:
  - `body_text` — decoded `text/plain` body
  - `body_html` — decoded `text/html` body
  - `attachments[]` — one entry per attachment with `{attachment_id, filename, mime_type, size}`
- **New tool `gmail_attachment_get`** fetches a specific attachment by `message_id + attachment_id` and returns base64url-encoded `data` + `size`. Attachment IDs flow from `gmail_message_get`'s `attachments` list.
- **`Client.GetAttachment`** wraps `Users.Messages.Attachments.Get`.

### Why
Enables the common workflow of filing email attachments to Drive:
```
gmail_messages_list (has:attachment)
  -> gmail_message_get (see attachments)
  -> gmail_attachment_get (data)
  -> drive_file_upload
```
Without this, attachments cannot be surfaced to the LLM at all.

### Implementation notes
- Base64url decoding restores padding manually; Gmail omits it on the wire per RFC 4648 §5 URL-safe alphabet.
- Recursion walks nested parts in API-returned order; first `text/plain` or `text/html` wins for body (matches typical Gmail structure).
- All existing response fields (`headers`, `snippet`, `labelIds`, `id`, `threadId`, `historyId`, `internalDate`, `sizeEstimate`, `account`) preserved — no regression risk.

## Test plan

- [x] `go build ./...`, `go test ./...` pass on both commits
- [x] Manual replay of Claude Code initialization sequence against the patched binary — `initialize` responds, `notifications/initialized` silently accepted, `resources/templates/list` + `prompts/list` return empty lists, `tools/list` returns all tools, connection stays open
- [x] Real Claude Code stdio session held through multiple tool calls
- [x] End-to-end attachment retrieval on a real multipart email (Partner bill, 2 PDF attachments):
  - `gmail_message_get` returns `body_html` + `attachments[]` with correct filenames and sizes
  - `gmail_attachment_get` returns base64url data that decodes cleanly to a valid PDF (`%PDF-1.7` magic, byte count matches reported `size`)