### PR TITLE
Support Shared Drives (supportsAllDrives) and per-account Sheets calls

### DIFF
--- a/drive/client.go
+++ b/drive/client.go
@@ -50,7 +50,9 @@ func (c *Client) ListFiles(query string, pageSize int64, parentID string) ([]*dr
 	defer cancel()
 
 	call := c.service.Files.List().
-		Fields("files(id, name, mimeType, size, modifiedTime, parents, webViewLink, iconLink, thumbnailLink)")
+		Fields("files(id, name, mimeType, size, modifiedTime, parents, webViewLink, iconLink, thumbnailLink)").
+		SupportsAllDrives(true).
+		IncludeItemsFromAllDrives(true)
 
 	// Build the query
 	finalQuery := query
@@ -119,6 +121,7 @@ func (c *Client) SearchFiles(name, mimeType string, modifiedAfter string) ([]*dr
 func (c *Client) GetFile(fileID string) (*drive.File, error) {
 	file, err := c.service.Files.Get(fileID).
 		Fields("id, name, mimeType, size, modifiedTime, parents, webViewLink, iconLink, thumbnailLink, permissions").
+		SupportsAllDrives(true).
 		Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get file: %w", err)
@@ -128,7 +131,7 @@ func (c *Client) GetFile(fileID string) (*drive.File, error) {
 
 // DownloadFile downloads a file
 func (c *Client) DownloadFile(fileID string, writer io.Writer) error {
-	resp, err := c.service.Files.Get(fileID).Download()
+	resp, err := c.service.Files.Get(fileID).SupportsAllDrives(true).Download()
 	if err != nil {
 		return fmt.Errorf("failed to download file: %w", err)
 	}
@@ -153,7 +156,7 @@ func (c *Client) UploadFile(name string, mimeType string, reader io.Reader, pare
 		file.Parents = []string{parentID}
 	}
 
-	call := c.service.Files.Create(file)
+	call := c.service.Files.Create(file).SupportsAllDrives(true)
 	if reader != nil {
 		call = call.Media(reader)
 	}
@@ -176,7 +179,7 @@ func (c *Client) UpdateFileMetadata(fileID, name, description string) (*drive.Fi
 		file.Description = description
 	}
 
-	updated, err := c.service.Files.Update(fileID, file).Do()
+	updated, err := c.service.Files.Update(fileID, file).SupportsAllDrives(true).Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to update file metadata: %w", err)
 	}
@@ -195,7 +198,7 @@ func (c *Client) CreateFolder(name string, parentID string) (*drive.File, error)
 		folder.Parents = []string{parentID}
 	}
 
-	created, err := c.service.Files.Create(folder).Do()
+	created, err := c.service.Files.Create(folder).SupportsAllDrives(true).Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create folder: %w", err)
 	}
@@ -221,6 +224,7 @@ func (c *Client) MoveFile(fileID, newParentID string) (*drive.File, error) {
 		AddParents(newParentID).
 		RemoveParents(removeParents).
 		Fields("id, parents").
+		SupportsAllDrives(true).
 		Do()
 
 	if err != nil {
@@ -237,7 +241,7 @@ func (c *Client) CopyFile(fileID, newName string) (*drive.File, error) {
 		copy.Name = newName
 	}
 
-	copied, err := c.service.Files.Copy(fileID, copy).Do()
+	copied, err := c.service.Files.Copy(fileID, copy).SupportsAllDrives(true).Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to copy file: %w", err)
 	}
@@ -247,7 +251,7 @@ func (c *Client) CopyFile(fileID, newName string) (*drive.File, error) {
 
 // DeleteFile deletes a file
 func (c *Client) DeleteFile(fileID string) error {
-	err := c.service.Files.Delete(fileID).Do()
+	err := c.service.Files.Delete(fileID).SupportsAllDrives(true).Do()
 	if err != nil {
 		return fmt.Errorf("failed to delete file: %w", err)
 	}
@@ -256,7 +260,7 @@ func (c *Client) DeleteFile(fileID string) error {
 
 // TrashFile moves a file to trash
 func (c *Client) TrashFile(fileID string) error {
-	_, err := c.service.Files.Update(fileID, &drive.File{Trashed: true}).Do()
+	_, err := c.service.Files.Update(fileID, &drive.File{Trashed: true}).SupportsAllDrives(true).Do()
 	if err != nil {
 		return fmt.Errorf("failed to trash file: %w", err)
 	}
@@ -265,7 +269,7 @@ func (c *Client) TrashFile(fileID string) error {
 
 // RestoreFile restores a file from trash
 func (c *Client) RestoreFile(fileID string) error {
-	_, err := c.service.Files.Update(fileID, &drive.File{Trashed: false}).Do()
+	_, err := c.service.Files.Update(fileID, &drive.File{Trashed: false}).SupportsAllDrives(true).Do()
 	if err != nil {
 		return fmt.Errorf("failed to restore file: %w", err)
 	}
@@ -279,7 +283,7 @@ func (c *Client) CreateShareLink(fileID string, role string) (string, error) {
 		Role: role, // "reader", "writer", etc.
 	}
 
-	_, err := c.service.Permissions.Create(fileID, permission).Do()
+	_, err := c.service.Permissions.Create(fileID, permission).SupportsAllDrives(true).Do()
 	if err != nil {
 		return "", fmt.Errorf("failed to create share link: %w", err)
 	}
@@ -296,6 +300,7 @@ func (c *Client) CreateShareLink(fileID string, role string) (string, error) {
 func (c *Client) ListPermissions(fileID string) ([]*drive.Permission, error) {
 	permissions, err := c.service.Permissions.List(fileID).
 		Fields("permissions(id, type, role, emailAddress)").
+		SupportsAllDrives(true).
 		Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list permissions: %w", err)
@@ -314,6 +319,7 @@ func (c *Client) CreatePermission(fileID, email, role string) (*drive.Permission
 
 	created, err := c.service.Permissions.Create(fileID, permission).
 		SendNotificationEmail(true).
+		SupportsAllDrives(true).
 		Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create permission: %w", err)
@@ -324,7 +330,7 @@ func (c *Client) CreatePermission(fileID, email, role string) (*drive.Permission
 
 // DeletePermission deletes a permission
 func (c *Client) DeletePermission(fileID, permissionID string) error {
-	err := c.service.Permissions.Delete(fileID, permissionID).Do()
+	err := c.service.Permissions.Delete(fileID, permissionID).SupportsAllDrives(true).Do()
 	if err != nil {
 		return fmt.Errorf("failed to delete permission: %w", err)
 	}
@@ -490,6 +496,7 @@ func (c *Client) UploadMarkdownAsDoc(ctx context.Context, name, markdown, parent
 	driveFile, err := c.service.Files.Create(file).
 		Media(reader).
 		Fields("id, name, mimeType, size, modifiedTime, parents, webViewLink, iconLink, thumbnailLink, createdTime").
+		SupportsAllDrives(true).
 		Context(ctx).
 		Do()
 
@@ -505,6 +512,7 @@ func (c *Client) ReplaceDocWithMarkdown(ctx context.Context, fileID, markdown st
 	// First, get the file metadata to ensure it's a Google Doc
 	file, err := c.service.Files.Get(fileID).
 		Fields("id, name, mimeType").
+		SupportsAllDrives(true).
 		Context(ctx).
 		Do()
 	if err != nil {
@@ -527,6 +535,7 @@ func (c *Client) ReplaceDocWithMarkdown(ctx context.Context, fileID, markdown st
 	updatedFile, err := c.service.Files.Update(fileID, &drive.File{}).
 		Media(reader).
 		Fields("id, name, mimeType, size, modifiedTime, parents, webViewLink, iconLink, thumbnailLink").
+		SupportsAllDrives(true).
 		Context(ctx).
 		Do()
 

--- a/main.go
+++ b/main.go
@@ -149,19 +149,24 @@ func registerServices(ctx context.Context, srv *server.MCPServer, accountManager
 		time.Sleep(serviceDelay)
 	}
 
-	// Initialize and register Sheets service
+	// Initialize and register Sheets service with multi-account support
 	if cfg.Services.Sheets.Enabled {
-		// Initialize Sheets service
-		initCtx, cancel := context.WithTimeout(ctx, initTimeout)
-		sheetsClient, err := sheets.NewClient(initCtx, oauth)
-		cancel()
-		if err != nil {
-			// Failed to initialize Sheets client, continue without it
-		} else {
-			sheetsHandler := sheets.NewHandler(sheetsClient)
-			srv.RegisterService("sheets", sheetsHandler)
-			// Sheets service registered
+		log.Println("[DEBUG] Initializing Sheets service...")
+		var sheetsClient *sheets.Client
+		if oauth != nil {
+			initCtx, cancel := context.WithTimeout(ctx, initTimeout)
+			var err error
+			sheetsClient, err = sheets.NewClient(initCtx, oauth)
+			cancel()
+			if err != nil {
+				log.Printf("[WARNING] Failed to initialize default Sheets client: %v\n", err)
+				sheetsClient = nil
+			}
 		}
+		// Use multi-account handler
+		sheetsHandler := sheets.NewMultiAccountHandler(accountManager, sheetsClient)
+		srv.RegisterService("sheets", sheetsHandler)
+		log.Println("[DEBUG] Sheets service registered with multi-account support")
 		// Add delay before next service
 		time.Sleep(serviceDelay)
 	}

--- a/sheets/multi_account.go
+++ b/sheets/multi_account.go
@@ -1,0 +1,204 @@
+package sheets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"go.ngs.io/google-mcp-server/auth"
+	"go.ngs.io/google-mcp-server/server"
+	"google.golang.org/api/option"
+	"google.golang.org/api/sheets/v4"
+)
+
+// MultiAccountClient manages Sheets operations across multiple accounts
+type MultiAccountClient struct {
+	accountManager *auth.AccountManager
+	clients        map[string]*Client
+	mu             sync.RWMutex
+}
+
+// NewMultiAccountClient creates a new multi-account Sheets client
+func NewMultiAccountClient(ctx context.Context, accountManager *auth.AccountManager) (*MultiAccountClient, error) {
+	mac := &MultiAccountClient{
+		accountManager: accountManager,
+		clients:        make(map[string]*Client),
+	}
+
+	// Initialize clients for all accounts
+	for email, oauthClient := range accountManager.GetAllOAuthClients() {
+		service, err := sheets.NewService(ctx, option.WithHTTPClient(oauthClient.GetHTTPClient()))
+		if err != nil {
+			fmt.Printf("Warning: failed to create sheets service for %s: %v\n", email, err)
+			continue
+		}
+		mac.clients[email] = &Client{service: service}
+	}
+
+	return mac, nil
+}
+
+// GetClientForContext returns the appropriate client based on context hints
+func (mac *MultiAccountClient) GetClientForContext(ctx context.Context, hint string) (*Client, string, error) {
+	// First try to get a specific account based on the hint
+	account, err := mac.accountManager.GetAccountForContext(ctx, hint)
+	if err == nil && account != nil {
+		mac.mu.RLock()
+		client, exists := mac.clients[account.Email]
+		mac.mu.RUnlock()
+
+		if exists {
+			return client, account.Email, nil
+		}
+
+		// Create client on demand if not exists
+		service, err := sheets.NewService(ctx, option.WithHTTPClient(account.OAuthClient.GetHTTPClient()))
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to create sheets service: %w", err)
+		}
+
+		newClient := &Client{service: service}
+		mac.mu.Lock()
+		mac.clients[account.Email] = newClient
+		mac.mu.Unlock()
+
+		return newClient, account.Email, nil
+	}
+
+	// If context is unclear but only one account exists, use it
+	accounts := mac.accountManager.ListAccounts()
+	if len(accounts) == 1 {
+		email := accounts[0].Email
+		mac.mu.RLock()
+		client, exists := mac.clients[email]
+		mac.mu.RUnlock()
+
+		if exists {
+			return client, email, nil
+		}
+	}
+
+	// Return error with available accounts
+	if len(accounts) == 0 {
+		return nil, "", fmt.Errorf("no authenticated accounts available")
+	}
+
+	var accountList []string
+	for _, acc := range accounts {
+		accountList = append(accountList, acc.Email)
+	}
+
+	return nil, "", fmt.Errorf("please specify account: %s", strings.Join(accountList, ", "))
+}
+
+// MultiAccountHandler handles Sheets operations with multi-account support
+type MultiAccountHandler struct {
+	multiClient *MultiAccountClient
+	handler     *Handler // Original handler for backward compatibility
+}
+
+// NewMultiAccountHandler creates a new handler with multi-account support
+func NewMultiAccountHandler(accountManager *auth.AccountManager, defaultClient *Client) *MultiAccountHandler {
+	ctx := context.Background()
+	multiClient, err := NewMultiAccountClient(ctx, accountManager)
+	if err != nil {
+		// Log error but continue with limited functionality
+		fmt.Printf("Warning: failed to initialize multi-account sheets client: %v\n", err)
+		multiClient = &MultiAccountClient{
+			accountManager: accountManager,
+			clients:        make(map[string]*Client),
+		}
+	}
+
+	// Create original handler for backward compatibility
+	var handler *Handler
+	if defaultClient != nil {
+		handler = NewHandler(defaultClient)
+	}
+
+	return &MultiAccountHandler{
+		multiClient: multiClient,
+		handler:     handler,
+	}
+}
+
+// GetTools returns the available Sheets tools with an added account parameter
+func (h *MultiAccountHandler) GetTools() []server.Tool {
+	if h.handler == nil {
+		return []server.Tool{}
+	}
+
+	tools := h.handler.GetTools()
+
+	// Add account parameter to existing tools
+	for i := range tools {
+		if tools[i].InputSchema.Properties == nil {
+			tools[i].InputSchema.Properties = make(map[string]server.Property)
+		}
+		tools[i].InputSchema.Properties["account"] = server.Property{
+			Type:        "string",
+			Description: "Email address of the account to use (optional)",
+		}
+	}
+
+	return tools
+}
+
+// HandleToolCall handles a tool call for Sheets service with multi-account support
+func (h *MultiAccountHandler) HandleToolCall(ctx context.Context, name string, arguments json.RawMessage) (interface{}, error) {
+	// Check if account parameter is provided
+	var accountHint string
+	if arguments != nil {
+		var args map[string]interface{}
+		if err := json.Unmarshal(arguments, &args); err == nil {
+			if account, ok := args["account"].(string); ok {
+				accountHint = account
+			}
+		}
+	}
+
+	// Try to get client for the specified account (or the sole account)
+	if h.multiClient != nil {
+		client, accountUsed, err := h.multiClient.GetClientForContext(ctx, accountHint)
+		if err == nil {
+			// Create a temporary handler with the selected client
+			tempHandler := NewHandler(client)
+			result, err := tempHandler.HandleToolCall(ctx, name, arguments)
+			if err != nil {
+				return nil, err
+			}
+
+			// Add account information to result if it's a map
+			if resultMap, ok := result.(map[string]interface{}); ok {
+				resultMap["account"] = accountUsed
+			}
+
+			return result, nil
+		}
+	}
+
+	// Fall back to original handler for backward compatibility
+	if h.handler != nil {
+		return h.handler.HandleToolCall(ctx, name, arguments)
+	}
+
+	return nil, fmt.Errorf("no handler available for tool: %s", name)
+}
+
+// GetResources returns the available Sheets resources
+func (h *MultiAccountHandler) GetResources() []server.Resource {
+	if h.handler != nil {
+		return h.handler.GetResources()
+	}
+	return []server.Resource{}
+}
+
+// HandleResourceCall handles a resource call for Sheets service
+func (h *MultiAccountHandler) HandleResourceCall(ctx context.Context, uri string) (interface{}, error) {
+	if h.handler != nil {
+		return h.handler.HandleResourceCall(ctx, uri)
+	}
+	return nil, fmt.Errorf("no handler available for resource: %s", uri)
+}


### PR DESCRIPTION
## Summary

Two fixes that let the server work with Google **Shared Drives** and with **multiple accounts** for Sheets.

### 1. Drive: Shared Drive support
Drive operations returned `404 File not found` for any file that lives in a Shared Drive, because the API calls didn't set `supportsAllDrives`. This adds `SupportsAllDrives(true)` to every `Files.*` and `Permissions.*` call in `drive/client.go`, plus `IncludeItemsFromAllDrives(true)` on the list call. `Files.Export` is left unchanged (its call type has no such option).

### 2. Sheets: per-account routing
The Sheets tools had no `account` parameter and always used the default OAuth client, so they failed with `403` for any non-default account. This adds `sheets/multi_account.go` — a `MultiAccountHandler` that mirrors the existing Drive/Calendar/Gmail handlers: it injects an optional `account` parameter into every Sheets tool and routes the call to the matching account's client. `main.go` now registers `sheets.NewMultiAccountHandler` instead of the single-account handler.

## Why
With these two changes, `sheets_values_get` / `sheets_values_update` / `sheets_spreadsheet_get` and the Drive metadata/download/update tools all work against spreadsheets stored in a Shared Drive when the right account is supplied — previously they returned 403 (wrong account) or 404 (Shared Drive).

## Testing
- `go build ./...` passes.
- Verified end-to-end over the MCP stdio protocol against a real Shared Drive spreadsheet: the three Sheets tools now expose an `account` parameter; a Sheets read with `account=<member of the shared drive>` returns data (was 403); `drive_file_get_metadata` returns the file (was 404).

## Notes
- No changes to public tool behavior for existing single-account setups — the `account` parameter is optional and falls back to the sole/default account.

---
Generated with Claude Code.