### PR TITLE
Fix startup panic and OAuth callback port handling in multi-account mode

### DIFF
--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -106,6 +106,9 @@ func DefaultScopes() []string {
 
 // GetHTTPClient returns the authenticated HTTP client
 func (c *OAuthClient) GetHTTPClient() *http.Client {
+	if c == nil {
+		return nil
+	}
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.httpClient

--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 
@@ -119,10 +122,66 @@ func (c *OAuthClient) GetClientOption() option.ClientOption {
 	return option.WithHTTPClient(c.GetHTTPClient())
 }
 
+// defaultCallbackPort is used when the configured redirect URI has no usable port
+const defaultCallbackPort = 8080
+
+// redirectURIPort returns the port of the configured redirect URI, falling back
+// to defaultCallbackPort when it cannot be determined.
+func redirectURIPort(redirectURI string) int {
+	parsed, err := url.Parse(redirectURI)
+	if err != nil {
+		return defaultCallbackPort
+	}
+
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil || port <= 0 || port > 65535 {
+		return defaultCallbackPort
+	}
+
+	return port
+}
+
+// startCallbackListener listens on the loopback interface, preferring the given
+// port and falling back to an ephemeral one when it is already taken.
+func startCallbackListener(preferredPort int) (net.Listener, error) {
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", preferredPort))
+	if err == nil {
+		return listener, nil
+	}
+
+	listener, err = net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("failed to start callback server: %w", err)
+	}
+
+	return listener, nil
+}
+
+// prepareCallback starts the callback listener and builds the authorization URL
+// for the port that was actually acquired.
+func (c *OAuthClient) prepareCallback() (net.Listener, string, error) {
+	listener, err := startCallbackListener(redirectURIPort(c.config.RedirectURL))
+	if err != nil {
+		return nil, "", err
+	}
+
+	// The redirect URI must match the port we ended up listening on, and it has
+	// to be set before the authorization URL is generated.
+	port := listener.Addr().(*net.TCPAddr).Port
+	c.config.RedirectURL = fmt.Sprintf("http://localhost:%d/callback", port)
+
+	return listener, c.config.AuthCodeURL("state-token", oauth2.AccessTypeOffline), nil
+}
+
 // authenticate performs the OAuth2 authentication flow
 func (c *OAuthClient) authenticate(ctx context.Context) error {
-	// Generate authorization URL
-	authURL := c.config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
+	// Start the callback listener first so the authorization URL carries the
+	// port we are actually listening on
+	listener, authURL, err := c.prepareCallback()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = listener.Close() }()
 
 	fmt.Printf("Opening browser for authentication...\n")
 	fmt.Printf("If browser doesn't open, visit this URL:\n%s\n", authURL)
@@ -137,7 +196,6 @@ func (c *OAuthClient) authenticate(ctx context.Context) error {
 	errChan := make(chan error, 1)
 
 	server := &http.Server{
-		Addr:              ":8080",
 		ReadHeaderTimeout: 10 * time.Second,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			code := r.URL.Query().Get("code")
@@ -158,7 +216,7 @@ func (c *OAuthClient) authenticate(ctx context.Context) error {
 	}
 
 	go func() {
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
 			errChan <- err
 		}
 	}()

--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -165,10 +165,10 @@ func (c *OAuthClient) prepareCallback() (net.Listener, string, error) {
 		return nil, "", err
 	}
 
-	// The redirect URI must match the port we ended up listening on, and it has
-	// to be set before the authorization URL is generated.
-	port := listener.Addr().(*net.TCPAddr).Port
-	c.config.RedirectURL = fmt.Sprintf("http://localhost:%d/callback", port)
+	// The redirect URI must point at the exact address we ended up listening on
+	// ("localhost" may resolve to ::1 while the listener is IPv4-only), and it
+	// has to be set before the authorization URL is generated.
+	c.config.RedirectURL = fmt.Sprintf("http://%s/callback", listener.Addr().String())
 
 	return listener, c.config.AuthCodeURL("state-token", oauth2.AccessTypeOffline), nil
 }

--- a/auth/oauth_test.go
+++ b/auth/oauth_test.go
@@ -80,6 +80,18 @@ func TestNewOAuthClientWithoutAuth(t *testing.T) {
 	}
 }
 
+func TestNilOAuthClientAccessors(t *testing.T) {
+	var client *OAuthClient
+
+	if httpClient := client.GetHTTPClient(); httpClient != nil {
+		t.Errorf("Expected nil HTTP client from nil receiver, got %v", httpClient)
+	}
+
+	if opt := client.GetClientOption(); opt == nil {
+		t.Error("Expected a client option from nil receiver, got nil")
+	}
+}
+
 func TestTokenFilePath(t *testing.T) {
 	tempDir := t.TempDir()
 	tokenFile := filepath.Join(tempDir, "test-token.json")

--- a/auth/oauth_test.go
+++ b/auth/oauth_test.go
@@ -2,9 +2,16 @@ package auth
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 )
 
 func TestDefaultScopes(t *testing.T) {
@@ -78,6 +85,119 @@ func TestNewOAuthClientWithoutAuth(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error with empty credentials")
 	}
+}
+
+func TestRedirectURIPort(t *testing.T) {
+	tests := []struct {
+		name        string
+		redirectURI string
+		want        int
+	}{
+		{"explicit port", "http://localhost:51011/callback", 51011},
+		{"default port", "http://localhost:8080/callback", 8080},
+		{"no port", "http://localhost/callback", defaultCallbackPort},
+		{"empty", "", defaultCallbackPort},
+		{"not a URL", "://nope", defaultCallbackPort},
+		{"out of range", "http://localhost:99999/callback", defaultCallbackPort},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redirectURIPort(tt.redirectURI); got != tt.want {
+				t.Errorf("redirectURIPort(%q) = %d, want %d", tt.redirectURI, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStartCallbackListenerUsesPreferredPort(t *testing.T) {
+	preferredPort := freePort(t)
+
+	listener, err := startCallbackListener(preferredPort)
+	if err != nil {
+		t.Fatalf("startCallbackListener failed: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	if addr.Port != preferredPort {
+		t.Errorf("Expected port %d, got %d", preferredPort, addr.Port)
+	}
+	if !addr.IP.Equal(net.IPv4(127, 0, 0, 1)) {
+		t.Errorf("Expected listener bound to 127.0.0.1, got %s", addr.IP)
+	}
+}
+
+// TestAuthenticatePortFallback verifies that a busy preferred port makes the
+// callback fall back to an ephemeral port, and that the authorization URL
+// advertises the port we actually listen on.
+func TestAuthenticatePortFallback(t *testing.T) {
+	busyPort := freePort(t)
+	blocker, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", busyPort))
+	if err != nil {
+		t.Fatalf("Failed to occupy port %d: %v", busyPort, err)
+	}
+	defer func() { _ = blocker.Close() }()
+
+	client := &OAuthClient{
+		config: &oauth2.Config{
+			ClientID:     "test-id",
+			ClientSecret: "test-secret",
+			RedirectURL:  fmt.Sprintf("http://localhost:%d/callback", busyPort),
+			Scopes:       DefaultScopes(),
+			Endpoint:     google.Endpoint,
+		},
+	}
+
+	listener, authURL, err := client.prepareCallback()
+	if err != nil {
+		t.Fatalf("prepareCallback failed: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	if addr.Port == busyPort {
+		t.Fatalf("Expected fallback to a different port, got the busy port %d", busyPort)
+	}
+	if !addr.IP.Equal(net.IPv4(127, 0, 0, 1)) {
+		t.Errorf("Expected listener bound to 127.0.0.1, got %s", addr.IP)
+	}
+
+	// The authorization URL must point at the port we actually listen on
+	parsed, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("Failed to parse authorization URL: %v", err)
+	}
+	redirectURI, err := url.Parse(parsed.Query().Get("redirect_uri"))
+	if err != nil {
+		t.Fatalf("Failed to parse redirect_uri: %v", err)
+	}
+	if redirectURI.Port() != strconv.Itoa(addr.Port) {
+		t.Errorf("redirect_uri port is %s, want %d", redirectURI.Port(), addr.Port)
+	}
+
+	// The fallback port must actually be reachable
+	conn, err := net.Dial("tcp", addr.String())
+	if err != nil {
+		t.Fatalf("Failed to connect to callback listener: %v", err)
+	}
+	_ = conn.Close()
+}
+
+// freePort returns a port that is free at the moment it is called.
+func freePort(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Failed to find a free port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatalf("Failed to release port %d: %v", port, err)
+	}
+
+	return port
 }
 
 func TestNilOAuthClientAccessors(t *testing.T) {

--- a/auth/oauth_test.go
+++ b/auth/oauth_test.go
@@ -175,6 +175,9 @@ func TestAuthenticatePortFallback(t *testing.T) {
 	if redirectURI.Port() != strconv.Itoa(addr.Port) {
 		t.Errorf("redirect_uri port is %s, want %d", redirectURI.Port(), addr.Port)
 	}
+	if redirectURI.Hostname() != addr.IP.String() {
+		t.Errorf("redirect_uri host is %s, want the bound address %s", redirectURI.Hostname(), addr.IP)
+	}
 
 	// The fallback port must actually be reachable
 	conn, err := net.Dial("tcp", addr.String())

--- a/docs/client.go
+++ b/docs/client.go
@@ -15,6 +15,10 @@ type Client struct {
 
 // NewClient creates a new Docs client
 func NewClient(ctx context.Context, oauth *auth.OAuthClient) (*Client, error) {
+	if oauth == nil {
+		return nil, fmt.Errorf("no OAuth client available")
+	}
+
 	service, err := docs.NewService(ctx, oauth.GetClientOption())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create docs service: %w", err)

--- a/docs/client_test.go
+++ b/docs/client_test.go
@@ -1,0 +1,16 @@
+package docs
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewClientWithNilOAuth(t *testing.T) {
+	client, err := NewClient(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected an error when the OAuth client is nil")
+	}
+	if client != nil {
+		t.Errorf("expected no client, got %v", client)
+	}
+}

--- a/drive/multi_account.go
+++ b/drive/multi_account.go
@@ -212,47 +212,43 @@ func NewMultiAccountHandler(accountManager *auth.AccountManager, defaultClient *
 	}
 }
 
-// GetTools returns the available Drive tools with multi-account support
+// GetTools returns the available Drive tools with multi-account support.
+// The tool list does not depend on a default OAuth client being available, so
+// the tools stay visible in multi-account-only setups.
 func (h *MultiAccountHandler) GetTools() []server.Tool {
-	// Get original tools from handler
-	if h.handler != nil {
-		tools := h.handler.GetTools()
+	tools := defaultDriveTools()
 
-		// Add account parameter to existing tools
-		for i := range tools {
-			if tools[i].InputSchema.Properties == nil {
-				tools[i].InputSchema.Properties = make(map[string]server.Property)
-			}
-			tools[i].InputSchema.Properties["account"] = server.Property{
-				Type:        "string",
-				Description: "Email address of the account to use (optional)",
-			}
+	// Add account parameter to existing tools
+	for i := range tools {
+		if tools[i].InputSchema.Properties == nil {
+			tools[i].InputSchema.Properties = make(map[string]server.Property)
 		}
-
-		// Add new multi-account specific tools
-		tools = append(tools, server.Tool{
-			Name:        "drive_files_list_all_accounts",
-			Description: "List files from all authenticated accounts",
-			InputSchema: server.InputSchema{
-				Type: "object",
-				Properties: map[string]server.Property{
-					"parent_id": {
-						Type:        "string",
-						Description: "Parent folder ID (optional, defaults to root)",
-					},
-					"page_size": {
-						Type:        "number",
-						Description: "Number of files per account (max 1000)",
-					},
-				},
-			},
-		})
-
-		return tools
+		tools[i].InputSchema.Properties["account"] = server.Property{
+			Type:        "string",
+			Description: "Email address of the account to use (optional)",
+		}
 	}
 
-	// Return empty if no handler
-	return []server.Tool{}
+	// Add new multi-account specific tools
+	tools = append(tools, server.Tool{
+		Name:        "drive_files_list_all_accounts",
+		Description: "List files from all authenticated accounts",
+		InputSchema: server.InputSchema{
+			Type: "object",
+			Properties: map[string]server.Property{
+				"parent_id": {
+					Type:        "string",
+					Description: "Parent folder ID (optional, defaults to root)",
+				},
+				"page_size": {
+					Type:        "number",
+					Description: "Number of files per account (max 1000)",
+				},
+			},
+		},
+	})
+
+	return tools
 }
 
 // HandleToolCall handles a tool call for Drive service with multi-account support
@@ -331,8 +327,10 @@ func (h *MultiAccountHandler) HandleToolCall(ctx context.Context, name string, a
 	}
 
 	// Try to get client for the specified account
+	var accountErr error
 	if accountHint != "" || h.multiClient != nil {
 		client, accountUsed, err := h.multiClient.GetClientForContext(ctx, accountHint)
+		accountErr = err
 		if err == nil {
 			// Create a temporary handler with the selected client
 			tempHandler := NewHandler(client)
@@ -353,6 +351,11 @@ func (h *MultiAccountHandler) HandleToolCall(ctx context.Context, name string, a
 	// Fall back to original handler for backward compatibility
 	if h.handler != nil {
 		return h.handler.HandleToolCall(ctx, name, arguments)
+	}
+
+	// Without a default client, surface why no account could be selected
+	if accountErr != nil {
+		return nil, accountErr
 	}
 
 	return nil, fmt.Errorf("no handler available for tool: %s", name)

--- a/drive/multi_account_test.go
+++ b/drive/multi_account_test.go
@@ -1,0 +1,90 @@
+package drive
+
+import (
+	"context"
+	"testing"
+
+	"go.ngs.io/google-mcp-server/auth"
+	"go.ngs.io/google-mcp-server/server"
+)
+
+func newTestAccountManager(t *testing.T) *auth.AccountManager {
+	t.Helper()
+
+	// Keep the account manager away from the real home directory
+	t.Setenv("HOME", t.TempDir())
+
+	am, err := auth.NewAccountManager(context.Background(), auth.OAuthConfig{})
+	if err != nil {
+		t.Fatalf("Failed to create account manager: %v", err)
+	}
+
+	return am
+}
+
+func toolNames(tools []server.Tool) map[string]server.Tool {
+	byName := make(map[string]server.Tool, len(tools))
+	for _, tool := range tools {
+		byName[tool.Name] = tool
+	}
+	return byName
+}
+
+// TestGetToolsWithoutDefaultClient covers the multi-account-only setup, where
+// no default OAuth client exists and the Drive tools must still be listed.
+func TestGetToolsWithoutDefaultClient(t *testing.T) {
+	handler := NewMultiAccountHandler(newTestAccountManager(t), nil)
+
+	tools := handler.GetTools()
+	if len(tools) == 0 {
+		t.Fatal("Expected Drive tools without a default client, got none")
+	}
+
+	byName := toolNames(tools)
+	for _, name := range []string{"drive_files_list", "drive_files_list_all_accounts"} {
+		if _, ok := byName[name]; !ok {
+			t.Errorf("Expected tool %s to be listed", name)
+		}
+	}
+
+	if _, ok := byName["drive_files_list"].InputSchema.Properties["account"]; !ok {
+		t.Error("Expected drive_files_list to accept an account parameter")
+	}
+}
+
+func TestGetToolsWithDefaultClient(t *testing.T) {
+	handler := NewMultiAccountHandler(newTestAccountManager(t), &Client{})
+
+	tools := handler.GetTools()
+	withoutClient := NewMultiAccountHandler(newTestAccountManager(t), nil).GetTools()
+
+	if len(tools) != len(withoutClient) {
+		t.Errorf("Expected the same number of tools with and without a default client, got %d and %d",
+			len(tools), len(withoutClient))
+	}
+
+	// The multi-account list is the base tool set plus the all-accounts tool
+	if len(tools) != len(defaultDriveTools())+1 {
+		t.Errorf("Expected %d tools, got %d", len(defaultDriveTools())+1, len(tools))
+	}
+
+	byName := toolNames(tools)
+	for _, name := range []string{"drive_files_list", "drive_files_list_all_accounts"} {
+		if _, ok := byName[name]; !ok {
+			t.Errorf("Expected tool %s to be listed", name)
+		}
+	}
+}
+
+// TestGetToolsDoesNotMutateDefaults ensures the account parameter injection
+// does not leak into the shared tool definitions.
+func TestGetToolsDoesNotMutateDefaults(t *testing.T) {
+	handler := NewMultiAccountHandler(newTestAccountManager(t), nil)
+	handler.GetTools()
+
+	for _, tool := range defaultDriveTools() {
+		if _, ok := tool.InputSchema.Properties["account"]; ok {
+			t.Errorf("Tool %s gained an account parameter in the shared definitions", tool.Name)
+		}
+	}
+}

--- a/drive/tools.go
+++ b/drive/tools.go
@@ -23,6 +23,12 @@ func NewHandler(client *Client) *Handler {
 
 // GetTools returns the available Drive tools
 func (h *Handler) GetTools() []server.Tool {
+	return defaultDriveTools()
+}
+
+// defaultDriveTools returns the Drive tool definitions. It is shared by Handler
+// and MultiAccountHandler so the definitions are not maintained twice.
+func defaultDriveTools() []server.Tool {
 	return []server.Tool{
 		{
 			Name:        "drive_files_list",

--- a/main.go
+++ b/main.go
@@ -151,16 +151,24 @@ func registerServices(ctx context.Context, srv *server.MCPServer, accountManager
 
 	// Initialize and register Sheets service
 	if cfg.Services.Sheets.Enabled {
-		// Initialize Sheets service
-		initCtx, cancel := context.WithTimeout(ctx, initTimeout)
-		sheetsClient, err := sheets.NewClient(initCtx, oauth)
-		cancel()
-		if err != nil {
-			// Failed to initialize Sheets client, continue without it
+		log.Println("[DEBUG] Initializing Sheets service...")
+		var sheetsClient *sheets.Client
+		if oauth != nil {
+			initCtx, cancel := context.WithTimeout(ctx, initTimeout)
+			var err error
+			sheetsClient, err = sheets.NewClient(initCtx, oauth)
+			cancel()
+			if err != nil {
+				log.Printf("[WARNING] Failed to initialize Sheets client: %v\n", err)
+				sheetsClient = nil
+			}
 		} else {
+			log.Println("[WARNING] Failed to initialize Sheets client: no default OAuth client available")
+		}
+		if sheetsClient != nil {
 			sheetsHandler := sheets.NewHandler(sheetsClient)
 			srv.RegisterService("sheets", sheetsHandler)
-			// Sheets service registered
+			log.Println("[DEBUG] Sheets service registered")
 		}
 		// Add delay before next service
 		time.Sleep(serviceDelay)
@@ -168,16 +176,24 @@ func registerServices(ctx context.Context, srv *server.MCPServer, accountManager
 
 	// Initialize and register Docs service
 	if cfg.Services.Docs.Enabled {
-		// Initialize Docs service
-		initCtx, cancel := context.WithTimeout(ctx, initTimeout)
-		docsClient, err := docs.NewClient(initCtx, oauth)
-		cancel()
-		if err != nil {
-			// Failed to initialize Docs client, continue without it
+		log.Println("[DEBUG] Initializing Docs service...")
+		var docsClient *docs.Client
+		if oauth != nil {
+			initCtx, cancel := context.WithTimeout(ctx, initTimeout)
+			var err error
+			docsClient, err = docs.NewClient(initCtx, oauth)
+			cancel()
+			if err != nil {
+				log.Printf("[WARNING] Failed to initialize Docs client: %v\n", err)
+				docsClient = nil
+			}
 		} else {
+			log.Println("[WARNING] Failed to initialize Docs client: no default OAuth client available")
+		}
+		if docsClient != nil {
 			docsHandler := docs.NewHandler(docsClient)
 			srv.RegisterService("docs", docsHandler)
-			// Docs service registered
+			log.Println("[DEBUG] Docs service registered")
 		}
 		// Add delay before next service
 		time.Sleep(serviceDelay)

--- a/main_test.go
+++ b/main_test.go
@@ -1,11 +1,48 @@
 package main
 
 import (
+	"context"
 	"testing"
+
+	"go.ngs.io/google-mcp-server/auth"
+	"go.ngs.io/google-mcp-server/config"
+	"go.ngs.io/google-mcp-server/server"
 )
 
 func TestInit(t *testing.T) {
 	// Basic test to ensure the package can be imported
 	// This is a placeholder test
 	t.Log("Main package initialized successfully")
+}
+
+// TestRegisterServicesWithNilOAuth ensures that multi-account mode (no default
+// OAuth client) registers services without panicking.
+func TestRegisterServicesWithNilOAuth(t *testing.T) {
+	// Isolate the account manager from the real home directory
+	t.Setenv("HOME", t.TempDir())
+
+	ctx := context.Background()
+
+	cfg := &config.Config{
+		Services: config.ServicesConfig{
+			Accounts: config.AccountsConfig{Enabled: true},
+			Calendar: config.CalendarConfig{Enabled: true},
+			Drive:    config.DriveConfig{Enabled: true},
+			Gmail:    config.GmailConfig{Enabled: true},
+			Sheets:   config.SheetsConfig{Enabled: true},
+			Docs:     config.DocsConfig{Enabled: true},
+			Slides:   config.SlidesConfig{Enabled: true},
+		},
+	}
+
+	accountManager, err := auth.NewAccountManager(ctx, cfg.OAuth)
+	if err != nil {
+		t.Fatalf("Failed to create account manager: %v", err)
+	}
+
+	srv := server.NewMCPServer(cfg)
+
+	if err := registerServices(ctx, srv, accountManager, nil, cfg); err != nil {
+		t.Fatalf("registerServices returned an error with a nil OAuth client: %v", err)
+	}
 }

--- a/sheets/client.go
+++ b/sheets/client.go
@@ -15,6 +15,10 @@ type Client struct {
 
 // NewClient creates a new Sheets client
 func NewClient(ctx context.Context, oauth *auth.OAuthClient) (*Client, error) {
+	if oauth == nil {
+		return nil, fmt.Errorf("no OAuth client available")
+	}
+
 	service, err := sheets.NewService(ctx, oauth.GetClientOption())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create sheets service: %w", err)

--- a/sheets/client_test.go
+++ b/sheets/client_test.go
@@ -1,0 +1,16 @@
+package sheets
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewClientWithNilOAuth(t *testing.T) {
+	client, err := NewClient(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected an error when the OAuth client is nil")
+	}
+	if client != nil {
+		t.Errorf("expected no client, got %v", client)
+	}
+}

--- a/slides/client.go
+++ b/slides/client.go
@@ -895,8 +895,8 @@ func (c *Client) BatchUpdate(presentationId string, requests []*slides.Request) 
 
 	return doWithRetry(func() (*slides.BatchUpdatePresentationResponse, error) {
 		return doWithRetry(func() (*slides.BatchUpdatePresentationResponse, error) {
-		return c.service.Presentations.BatchUpdate(presentationId, req).Do()
-	})
+			return c.service.Presentations.BatchUpdate(presentationId, req).Do()
+		})
 	})
 }
 

--- a/slides/client.go
+++ b/slides/client.go
@@ -75,6 +75,10 @@ type Client struct {
 }
 
 func NewClient(ctx context.Context, client *http.Client) (*Client, error) {
+	if client == nil {
+		return nil, fmt.Errorf("no authenticated HTTP client available")
+	}
+
 	service, err := slides.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create slides service: %w", err)

--- a/slides/client_test.go
+++ b/slides/client_test.go
@@ -11,9 +11,10 @@ func TestNewClient(t *testing.T) {
 	// Test with nil HTTP client
 	ctx := context.Background()
 	client, err := NewClient(ctx, nil)
-	// The actual behavior depends on the Google API client library
-	// It may or may not return an error with nil client
-	if err != nil && client != nil {
+	if err == nil {
+		t.Fatal("NewClient() should return an error when the HTTP client is nil")
+	}
+	if client != nil {
 		t.Error("NewClient() should return nil client when error occurs")
 	}
 


### PR DESCRIPTION
## Summary

Fixes three independent bugs that surface on first launch (no stored tokens) when port 8080 is occupied by another process:

1. **Startup panic without a default OAuth client** — `registerServices` passed a nil `*auth.OAuthClient` to `sheets.NewClient` / `docs.NewClient`, which dereference it unconditionally (`oauth.GetClientOption()` → SIGSEGV). Multi-account-only mode effectively always crashed on startup.
2. **OAuth callback server hardcoded to `:8080`** — `authenticate()` used `http.Server{Addr: ":8080"}`, so authentication failed outright when the port was taken, and the listener was bound on all interfaces.
3. **Drive exposed zero tools in multi-account-only mode** — `MultiAccountHandler.GetTools()` returned an empty slice when no default-client handler existed, while Calendar/Gmail listed their tools fine.

## Changes

### Nil OAuth client handling
- `main.go`: Sheets/Docs registration now follows the same `if oauth != nil` pattern as Calendar/Drive/Gmail, and logs a `[WARNING]` instead of silently swallowing initialization failures
- `auth.GetHTTPClient()` guards against a nil receiver
- `sheets.NewClient` / `docs.NewClient` / `slides.NewClient` return an error instead of panicking when given no client

### Dynamic loopback port for the OAuth callback
- The callback listener now binds to `127.0.0.1`, preferring the port from the configured `redirect_uri` (default 8080) and falling back to an ephemeral port when it is taken
- The redirect URI is updated to the acquired port before the authorization URL is generated, so the `redirect_uri` parameter always matches the actual listener
- Google Desktop app clients accept any loopback port, so the fallback works without Cloud Console changes

### Drive tools in multi-account-only mode
- Tool definitions moved to a shared `defaultDriveTools()` used by both `Handler` and `MultiAccountHandler`, so the list no longer depends on a default OAuth client
- `HandleToolCall` surfaces the account-selection error instead of a generic "no handler available" when no default handler exists

Also fixes a pre-existing gofmt violation in `slides/client.go`.

## Testing

- `go test ./...`, `go vet ./...`, `gofmt -l` all clean
- New tests: `TestRegisterServicesWithNilOAuth`, nil-client tests for Sheets/Docs/Slides, `TestAuthenticatePortFallback` / `TestStartCallbackListenerUsesPreferredPort` / `TestRedirectURIPort`, and Drive `TestGetToolsWithoutDefaultClient` / `TestGetToolsWithDefaultClient` / `TestGetToolsDoesNotMutateDefaults`