### PR TITLE
Integrate community PRs: Shared Drives, per-account Sheets, and full-text Drive search

### DIFF
--- a/drive/client.go
+++ b/drive/client.go
@@ -93,8 +93,14 @@ func (c *Client) ListFiles(query string, pageSize int64, parentID string) ([]*dr
 	return fileList.Files, nil
 }
 
+// SearchOptions holds optional parameters for SearchFiles.
+type SearchOptions struct {
+	FullText string
+	FolderID string // If set, results are filtered client-side to files within this folder (recursive)
+}
+
 // SearchFiles searches for files
-func (c *Client) SearchFiles(name, mimeType string, modifiedAfter string) ([]*drive.File, error) {
+func (c *Client) SearchFiles(name, mimeType, modifiedAfter string, opts SearchOptions) ([]*drive.File, error) {
 	query := ""
 	if name != "" {
 		query = fmt.Sprintf("name contains '%s'", name)
@@ -111,8 +117,58 @@ func (c *Client) SearchFiles(name, mimeType string, modifiedAfter string) ([]*dr
 		}
 		query += fmt.Sprintf("modifiedTime > '%s'", modifiedAfter)
 	}
+	if opts.FullText != "" {
+		if query != "" {
+			query += " and "
+		}
+		query += fmt.Sprintf("fullText contains '%s'", opts.FullText)
+	}
 
-	return c.ListFiles(query, 100, "")
+	files, err := c.ListFiles(query, 100, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.FolderID != "" {
+		cache := make(map[string]bool)
+		filtered := files[:0]
+		for _, f := range files {
+			if c.isDescendantOf(f.Parents, opts.FolderID, cache) {
+				filtered = append(filtered, f)
+			}
+		}
+		files = filtered
+	}
+
+	return files, nil
+}
+
+// isDescendantOf checks whether a file (identified by its direct parents) is inside targetFolderID,
+// walking up the folder tree recursively. cache maps folder IDs to their result to avoid redundant API calls.
+func (c *Client) isDescendantOf(parents []string, targetFolderID string, cache map[string]bool) bool {
+	for _, parentID := range parents {
+		if parentID == targetFolderID {
+			return true
+		}
+		if cached, ok := cache[parentID]; ok {
+			if cached {
+				return true
+			}
+			continue
+		}
+		// Mark false first to handle any cycles
+		cache[parentID] = false
+		parent, err := c.GetFile(parentID)
+		if err != nil || len(parent.Parents) == 0 {
+			continue
+		}
+		result := c.isDescendantOf(parent.Parents, targetFolderID, cache)
+		cache[parentID] = result
+		if result {
+			return true
+		}
+	}
+	return false
 }
 
 // GetFile gets file metadata

--- a/drive/client.go
+++ b/drive/client.go
@@ -95,6 +95,16 @@ func (c *Client) ListFiles(query string, pageSize int64, parentID string) ([]*dr
 	return fileList.Files, nil
 }
 
+const (
+	// searchPageSize is the number of results fetched for a plain search
+	searchPageSize = 100
+	// searchPageSizeWithFolderFilter is used when results are filtered
+	// client-side by folder, where a larger page reduces false negatives
+	searchPageSizeWithFolderFilter = 1000
+	// folderLookupTimeout bounds each parent lookup during ancestry walks
+	folderLookupTimeout = 10 * time.Second
+)
+
 // SearchOptions holds optional parameters for SearchFiles.
 type SearchOptions struct {
 	FullText string
@@ -126,7 +136,14 @@ func (c *Client) SearchFiles(name, mimeType, modifiedAfter string, opts SearchOp
 		query += fmt.Sprintf("fullText contains '%s'", opts.FullText)
 	}
 
-	files, err := c.ListFiles(query, 100, "")
+	// Folder filtering happens client-side after a global search, so fetch a
+	// larger page to reduce the chance of matches falling outside the results.
+	pageSize := int64(searchPageSize)
+	if opts.FolderID != "" {
+		pageSize = searchPageSizeWithFolderFilter
+	}
+
+	files, err := c.ListFiles(query, pageSize, "")
 	if err != nil {
 		return nil, err
 	}
@@ -145,6 +162,24 @@ func (c *Client) SearchFiles(name, mimeType, modifiedAfter string, opts SearchOp
 	return files, nil
 }
 
+// getParents fetches only the parents of a folder, which is all the ancestry
+// walk needs. It avoids the much larger field set GetFile requests.
+func (c *Client) getParents(fileID string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), folderLookupTimeout)
+	defer cancel()
+
+	file, err := c.service.Files.Get(fileID).
+		Fields("parents").
+		SupportsAllDrives(true).
+		Context(ctx).
+		Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get parents of %s: %w", fileID, err)
+	}
+
+	return file.Parents, nil
+}
+
 // isDescendantOf checks whether a file (identified by its direct parents) is inside targetFolderID,
 // walking up the folder tree recursively. cache maps folder IDs to their result to avoid redundant API calls.
 func (c *Client) isDescendantOf(parents []string, targetFolderID string, cache map[string]bool) bool {
@@ -160,11 +195,11 @@ func (c *Client) isDescendantOf(parents []string, targetFolderID string, cache m
 		}
 		// Mark false first to handle any cycles
 		cache[parentID] = false
-		parent, err := c.GetFile(parentID)
-		if err != nil || len(parent.Parents) == 0 {
+		grandParents, err := c.getParents(parentID)
+		if err != nil || len(grandParents) == 0 {
 			continue
 		}
-		result := c.isDescendantOf(parent.Parents, targetFolderID, cache)
+		result := c.isDescendantOf(grandParents, targetFolderID, cache)
 		cache[parentID] = result
 		if result {
 			return true

--- a/drive/client.go
+++ b/drive/client.go
@@ -50,7 +50,9 @@ func (c *Client) ListFiles(query string, pageSize int64, parentID string) ([]*dr
 	defer cancel()
 
 	call := c.service.Files.List().
-		Fields("files(id, name, mimeType, size, modifiedTime, parents, webViewLink, iconLink, thumbnailLink)")
+		Fields("files(id, name, mimeType, size, modifiedTime, parents, webViewLink, iconLink, thumbnailLink)").
+		SupportsAllDrives(true).
+		IncludeItemsFromAllDrives(true)
 
 	// Build the query
 	finalQuery := query
@@ -119,6 +121,7 @@ func (c *Client) SearchFiles(name, mimeType string, modifiedAfter string) ([]*dr
 func (c *Client) GetFile(fileID string) (*drive.File, error) {
 	file, err := c.service.Files.Get(fileID).
 		Fields("id, name, mimeType, size, modifiedTime, parents, webViewLink, iconLink, thumbnailLink, permissions").
+		SupportsAllDrives(true).
 		Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get file: %w", err)
@@ -128,7 +131,7 @@ func (c *Client) GetFile(fileID string) (*drive.File, error) {
 
 // DownloadFile downloads a file
 func (c *Client) DownloadFile(fileID string, writer io.Writer) error {
-	resp, err := c.service.Files.Get(fileID).Download()
+	resp, err := c.service.Files.Get(fileID).SupportsAllDrives(true).Download()
 	if err != nil {
 		return fmt.Errorf("failed to download file: %w", err)
 	}
@@ -153,7 +156,7 @@ func (c *Client) UploadFile(name string, mimeType string, reader io.Reader, pare
 		file.Parents = []string{parentID}
 	}
 
-	call := c.service.Files.Create(file)
+	call := c.service.Files.Create(file).SupportsAllDrives(true)
 	if reader != nil {
 		call = call.Media(reader)
 	}
@@ -176,7 +179,7 @@ func (c *Client) UpdateFileMetadata(fileID, name, description string) (*drive.Fi
 		file.Description = description
 	}
 
-	updated, err := c.service.Files.Update(fileID, file).Do()
+	updated, err := c.service.Files.Update(fileID, file).SupportsAllDrives(true).Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to update file metadata: %w", err)
 	}
@@ -195,7 +198,7 @@ func (c *Client) CreateFolder(name string, parentID string) (*drive.File, error)
 		folder.Parents = []string{parentID}
 	}
 
-	created, err := c.service.Files.Create(folder).Do()
+	created, err := c.service.Files.Create(folder).SupportsAllDrives(true).Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create folder: %w", err)
 	}
@@ -221,6 +224,7 @@ func (c *Client) MoveFile(fileID, newParentID string) (*drive.File, error) {
 		AddParents(newParentID).
 		RemoveParents(removeParents).
 		Fields("id, parents").
+		SupportsAllDrives(true).
 		Do()
 
 	if err != nil {
@@ -237,7 +241,7 @@ func (c *Client) CopyFile(fileID, newName string) (*drive.File, error) {
 		copy.Name = newName
 	}
 
-	copied, err := c.service.Files.Copy(fileID, copy).Do()
+	copied, err := c.service.Files.Copy(fileID, copy).SupportsAllDrives(true).Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to copy file: %w", err)
 	}
@@ -247,7 +251,7 @@ func (c *Client) CopyFile(fileID, newName string) (*drive.File, error) {
 
 // DeleteFile deletes a file
 func (c *Client) DeleteFile(fileID string) error {
-	err := c.service.Files.Delete(fileID).Do()
+	err := c.service.Files.Delete(fileID).SupportsAllDrives(true).Do()
 	if err != nil {
 		return fmt.Errorf("failed to delete file: %w", err)
 	}
@@ -256,7 +260,7 @@ func (c *Client) DeleteFile(fileID string) error {
 
 // TrashFile moves a file to trash
 func (c *Client) TrashFile(fileID string) error {
-	_, err := c.service.Files.Update(fileID, &drive.File{Trashed: true}).Do()
+	_, err := c.service.Files.Update(fileID, &drive.File{Trashed: true}).SupportsAllDrives(true).Do()
 	if err != nil {
 		return fmt.Errorf("failed to trash file: %w", err)
 	}
@@ -265,7 +269,7 @@ func (c *Client) TrashFile(fileID string) error {
 
 // RestoreFile restores a file from trash
 func (c *Client) RestoreFile(fileID string) error {
-	_, err := c.service.Files.Update(fileID, &drive.File{Trashed: false}).Do()
+	_, err := c.service.Files.Update(fileID, &drive.File{Trashed: false}).SupportsAllDrives(true).Do()
 	if err != nil {
 		return fmt.Errorf("failed to restore file: %w", err)
 	}
@@ -279,7 +283,7 @@ func (c *Client) CreateShareLink(fileID string, role string) (string, error) {
 		Role: role, // "reader", "writer", etc.
 	}
 
-	_, err := c.service.Permissions.Create(fileID, permission).Do()
+	_, err := c.service.Permissions.Create(fileID, permission).SupportsAllDrives(true).Do()
 	if err != nil {
 		return "", fmt.Errorf("failed to create share link: %w", err)
 	}
@@ -296,6 +300,7 @@ func (c *Client) CreateShareLink(fileID string, role string) (string, error) {
 func (c *Client) ListPermissions(fileID string) ([]*drive.Permission, error) {
 	permissions, err := c.service.Permissions.List(fileID).
 		Fields("permissions(id, type, role, emailAddress)").
+		SupportsAllDrives(true).
 		Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list permissions: %w", err)
@@ -314,6 +319,7 @@ func (c *Client) CreatePermission(fileID, email, role string) (*drive.Permission
 
 	created, err := c.service.Permissions.Create(fileID, permission).
 		SendNotificationEmail(true).
+		SupportsAllDrives(true).
 		Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create permission: %w", err)
@@ -324,7 +330,7 @@ func (c *Client) CreatePermission(fileID, email, role string) (*drive.Permission
 
 // DeletePermission deletes a permission
 func (c *Client) DeletePermission(fileID, permissionID string) error {
-	err := c.service.Permissions.Delete(fileID, permissionID).Do()
+	err := c.service.Permissions.Delete(fileID, permissionID).SupportsAllDrives(true).Do()
 	if err != nil {
 		return fmt.Errorf("failed to delete permission: %w", err)
 	}
@@ -490,6 +496,7 @@ func (c *Client) UploadMarkdownAsDoc(ctx context.Context, name, markdown, parent
 	driveFile, err := c.service.Files.Create(file).
 		Media(reader).
 		Fields("id, name, mimeType, size, modifiedTime, parents, webViewLink, iconLink, thumbnailLink, createdTime").
+		SupportsAllDrives(true).
 		Context(ctx).
 		Do()
 
@@ -505,6 +512,7 @@ func (c *Client) ReplaceDocWithMarkdown(ctx context.Context, fileID, markdown st
 	// First, get the file metadata to ensure it's a Google Doc
 	file, err := c.service.Files.Get(fileID).
 		Fields("id, name, mimeType").
+		SupportsAllDrives(true).
 		Context(ctx).
 		Do()
 	if err != nil {
@@ -527,6 +535,7 @@ func (c *Client) ReplaceDocWithMarkdown(ctx context.Context, fileID, markdown st
 	updatedFile, err := c.service.Files.Update(fileID, &drive.File{}).
 		Media(reader).
 		Fields("id, name, mimeType, size, modifiedTime, parents, webViewLink, iconLink, thumbnailLink").
+		SupportsAllDrives(true).
 		Context(ctx).
 		Do()
 

--- a/drive/client.go
+++ b/drive/client.go
@@ -50,7 +50,7 @@ func (c *Client) ListFiles(query string, pageSize int64, parentID string) ([]*dr
 	defer cancel()
 
 	call := c.service.Files.List().
-		Fields("files(id, name, mimeType, size, modifiedTime, parents, webViewLink, iconLink, thumbnailLink)").
+		Fields("files(id, name, mimeType, size, modifiedTime, parents, webViewLink, iconLink, thumbnailLink, driveId)").
 		SupportsAllDrives(true).
 		IncludeItemsFromAllDrives(true)
 
@@ -176,7 +176,7 @@ func (c *Client) isDescendantOf(parents []string, targetFolderID string, cache m
 // GetFile gets file metadata
 func (c *Client) GetFile(fileID string) (*drive.File, error) {
 	file, err := c.service.Files.Get(fileID).
-		Fields("id, name, mimeType, size, modifiedTime, parents, webViewLink, iconLink, thumbnailLink, permissions").
+		Fields("id, name, mimeType, size, modifiedTime, parents, webViewLink, iconLink, thumbnailLink, permissions, driveId").
 		SupportsAllDrives(true).
 		Do()
 	if err != nil {

--- a/drive/client_test.go
+++ b/drive/client_test.go
@@ -564,6 +564,108 @@ func TestConvertMarkdownToHTML_Styles(t *testing.T) {
 	}
 }
 
+// captureTransport records the last request URL for query inspection.
+type captureTransport struct {
+	lastRequest *http.Request
+}
+
+func (t *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.lastRequest = req
+	body := `{"files": []}`
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}, nil
+}
+
+func newClientWithCapture(t *testing.T) (*Client, *captureTransport) {
+	t.Helper()
+	ct := &captureTransport{}
+	httpClient := &http.Client{Transport: ct}
+	service, err := drive.NewService(context.Background(), option.WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("Failed to create Drive service: %v", err)
+	}
+	return &Client{service: service}, ct
+}
+
+func TestSearchFiles_FullText(t *testing.T) {
+	client, ct := newClientWithCapture(t)
+
+	_, err := client.SearchFiles("", "", "", SearchOptions{FullText: "buttercup"})
+	if err != nil {
+		t.Fatalf("SearchFiles() error = %v", err)
+	}
+
+	q := ct.lastRequest.URL.Query().Get("q")
+	if !strings.Contains(q, "fullText contains 'buttercup'") {
+		t.Errorf("expected q to contain fullText clause, got: %q", q)
+	}
+}
+
+func TestSearchFiles_FolderID_NotInQuery(t *testing.T) {
+	client, ct := newClientWithCapture(t)
+
+	_, err := client.SearchFiles("", "", "", SearchOptions{FullText: "buttercup", FolderID: "folder123"})
+	if err != nil {
+		t.Fatalf("SearchFiles() error = %v", err)
+	}
+
+	q := ct.lastRequest.URL.Query().Get("q")
+	if !strings.Contains(q, "fullText contains 'buttercup'") {
+		t.Errorf("expected q to contain fullText clause, got: %q", q)
+	}
+	// FolderID filtering is client-side; folder ID must NOT appear in the Drive API query
+	if strings.Contains(q, "folder123") {
+		t.Errorf("folder ID should be absent from API query (filtering is client-side), got: %q", q)
+	}
+}
+
+func TestSearchFiles_AllParams(t *testing.T) {
+	client, ct := newClientWithCapture(t)
+
+	_, err := client.SearchFiles("budget", "text/markdown", "2025-01-01T00:00:00Z", SearchOptions{FullText: "tax", FolderID: "folder789"})
+	if err != nil {
+		t.Fatalf("SearchFiles() error = %v", err)
+	}
+
+	q := ct.lastRequest.URL.Query().Get("q")
+	for _, want := range []string{
+		"name contains 'budget'",
+		"mimeType = 'text/markdown'",
+		"modifiedTime > '2025-01-01T00:00:00Z'",
+		"fullText contains 'tax'",
+	} {
+		if !strings.Contains(q, want) {
+			t.Errorf("expected q to contain %q, got: %q", want, q)
+		}
+	}
+	if strings.Contains(q, "folder789") {
+		t.Errorf("folder ID should be absent from API query (filtering is client-side), got: %q", q)
+	}
+}
+
+func TestSearchFiles_NoOpts_BackwardCompat(t *testing.T) {
+	client, ct := newClientWithCapture(t)
+
+	_, err := client.SearchFiles("report", "", "", SearchOptions{})
+	if err != nil {
+		t.Fatalf("SearchFiles() error = %v", err)
+	}
+
+	q := ct.lastRequest.URL.Query().Get("q")
+	if !strings.Contains(q, "name contains 'report'") {
+		t.Errorf("expected q to contain name clause, got: %q", q)
+	}
+	if strings.Contains(q, "fullText") {
+		t.Errorf("expected no fullText clause when FullText is empty, got: %q", q)
+	}
+	if strings.Contains(q, "in parents") {
+		t.Errorf("expected no parent clause when FolderID is empty, got: %q", q)
+	}
+}
+
 func BenchmarkConvertMarkdownToHTML(b *testing.B) {
 	markdown := `# Benchmark Document
 

--- a/drive/tools.go
+++ b/drive/tools.go
@@ -59,6 +59,14 @@ func (h *Handler) GetTools() []server.Tool {
 						Type:        "string",
 						Description: "Modified after date (RFC3339 format)",
 					},
+					"full_text": {
+						Type:        "string",
+						Description: "Full-text search query (searches file contents)",
+					},
+					"folder_id": {
+						Type:        "string",
+						Description: "Restrict results to files inside this folder (recursive); filtering is done client-side after a global fullText search",
+					},
 				},
 			},
 		},
@@ -369,11 +377,13 @@ func (h *Handler) HandleToolCall(ctx context.Context, name string, arguments jso
 			Name          string `json:"name"`
 			MimeType      string `json:"mime_type"`
 			ModifiedAfter string `json:"modified_after"`
+			FullText      string `json:"full_text"`
+			FolderID      string `json:"folder_id"`
 		}
 		if err := json.Unmarshal(arguments, &args); err != nil {
 			return nil, fmt.Errorf("invalid arguments: %w", err)
 		}
-		return h.handleFilesSearch(ctx, args.Name, args.MimeType, args.ModifiedAfter)
+		return h.handleFilesSearch(ctx, args.Name, args.MimeType, args.ModifiedAfter, args.FullText, args.FolderID)
 
 	case "drive_file_download":
 		var args struct {
@@ -555,8 +565,8 @@ func (h *Handler) handleFilesList(ctx context.Context, parentID string, pageSize
 	}, nil
 }
 
-func (h *Handler) handleFilesSearch(ctx context.Context, name, mimeType, modifiedAfter string) (interface{}, error) {
-	files, err := h.client.SearchFiles(name, mimeType, modifiedAfter)
+func (h *Handler) handleFilesSearch(ctx context.Context, name, mimeType, modifiedAfter, fullText, folderID string) (interface{}, error) {
+	files, err := h.client.SearchFiles(name, mimeType, modifiedAfter, SearchOptions{FullText: fullText, FolderID: folderID})
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -149,19 +149,24 @@ func registerServices(ctx context.Context, srv *server.MCPServer, accountManager
 		time.Sleep(serviceDelay)
 	}
 
-	// Initialize and register Sheets service
+	// Initialize and register Sheets service with multi-account support
 	if cfg.Services.Sheets.Enabled {
-		// Initialize Sheets service
-		initCtx, cancel := context.WithTimeout(ctx, initTimeout)
-		sheetsClient, err := sheets.NewClient(initCtx, oauth)
-		cancel()
-		if err != nil {
-			// Failed to initialize Sheets client, continue without it
-		} else {
-			sheetsHandler := sheets.NewHandler(sheetsClient)
-			srv.RegisterService("sheets", sheetsHandler)
-			// Sheets service registered
+		log.Println("[DEBUG] Initializing Sheets service...")
+		var sheetsClient *sheets.Client
+		if oauth != nil {
+			initCtx, cancel := context.WithTimeout(ctx, initTimeout)
+			var err error
+			sheetsClient, err = sheets.NewClient(initCtx, oauth)
+			cancel()
+			if err != nil {
+				log.Printf("[WARNING] Failed to initialize default Sheets client: %v\n", err)
+				sheetsClient = nil
+			}
 		}
+		// Use multi-account handler
+		sheetsHandler := sheets.NewMultiAccountHandler(accountManager, sheetsClient)
+		srv.RegisterService("sheets", sheetsHandler)
+		log.Println("[DEBUG] Sheets service registered with multi-account support")
 		// Add delay before next service
 		time.Sleep(serviceDelay)
 	}

--- a/sheets/multi_account.go
+++ b/sheets/multi_account.go
@@ -124,13 +124,11 @@ func NewMultiAccountHandler(accountManager *auth.AccountManager, defaultClient *
 	}
 }
 
-// GetTools returns the available Sheets tools with an added account parameter
+// GetTools returns the available Sheets tools with an added account parameter.
+// The tool list does not depend on a default OAuth client being available, so
+// the tools stay visible in multi-account-only setups.
 func (h *MultiAccountHandler) GetTools() []server.Tool {
-	if h.handler == nil {
-		return []server.Tool{}
-	}
-
-	tools := h.handler.GetTools()
+	tools := defaultSheetsTools()
 
 	// Add account parameter to existing tools
 	for i := range tools {

--- a/sheets/multi_account.go
+++ b/sheets/multi_account.go
@@ -1,0 +1,204 @@
+package sheets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"go.ngs.io/google-mcp-server/auth"
+	"go.ngs.io/google-mcp-server/server"
+	"google.golang.org/api/option"
+	"google.golang.org/api/sheets/v4"
+)
+
+// MultiAccountClient manages Sheets operations across multiple accounts
+type MultiAccountClient struct {
+	accountManager *auth.AccountManager
+	clients        map[string]*Client
+	mu             sync.RWMutex
+}
+
+// NewMultiAccountClient creates a new multi-account Sheets client
+func NewMultiAccountClient(ctx context.Context, accountManager *auth.AccountManager) (*MultiAccountClient, error) {
+	mac := &MultiAccountClient{
+		accountManager: accountManager,
+		clients:        make(map[string]*Client),
+	}
+
+	// Initialize clients for all accounts
+	for email, oauthClient := range accountManager.GetAllOAuthClients() {
+		service, err := sheets.NewService(ctx, option.WithHTTPClient(oauthClient.GetHTTPClient()))
+		if err != nil {
+			fmt.Printf("Warning: failed to create sheets service for %s: %v\n", email, err)
+			continue
+		}
+		mac.clients[email] = &Client{service: service}
+	}
+
+	return mac, nil
+}
+
+// GetClientForContext returns the appropriate client based on context hints
+func (mac *MultiAccountClient) GetClientForContext(ctx context.Context, hint string) (*Client, string, error) {
+	// First try to get a specific account based on the hint
+	account, err := mac.accountManager.GetAccountForContext(ctx, hint)
+	if err == nil && account != nil {
+		mac.mu.RLock()
+		client, exists := mac.clients[account.Email]
+		mac.mu.RUnlock()
+
+		if exists {
+			return client, account.Email, nil
+		}
+
+		// Create client on demand if not exists
+		service, err := sheets.NewService(ctx, option.WithHTTPClient(account.OAuthClient.GetHTTPClient()))
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to create sheets service: %w", err)
+		}
+
+		newClient := &Client{service: service}
+		mac.mu.Lock()
+		mac.clients[account.Email] = newClient
+		mac.mu.Unlock()
+
+		return newClient, account.Email, nil
+	}
+
+	// If context is unclear but only one account exists, use it
+	accounts := mac.accountManager.ListAccounts()
+	if len(accounts) == 1 {
+		email := accounts[0].Email
+		mac.mu.RLock()
+		client, exists := mac.clients[email]
+		mac.mu.RUnlock()
+
+		if exists {
+			return client, email, nil
+		}
+	}
+
+	// Return error with available accounts
+	if len(accounts) == 0 {
+		return nil, "", fmt.Errorf("no authenticated accounts available")
+	}
+
+	var accountList []string
+	for _, acc := range accounts {
+		accountList = append(accountList, acc.Email)
+	}
+
+	return nil, "", fmt.Errorf("please specify account: %s", strings.Join(accountList, ", "))
+}
+
+// MultiAccountHandler handles Sheets operations with multi-account support
+type MultiAccountHandler struct {
+	multiClient *MultiAccountClient
+	handler     *Handler // Original handler for backward compatibility
+}
+
+// NewMultiAccountHandler creates a new handler with multi-account support
+func NewMultiAccountHandler(accountManager *auth.AccountManager, defaultClient *Client) *MultiAccountHandler {
+	ctx := context.Background()
+	multiClient, err := NewMultiAccountClient(ctx, accountManager)
+	if err != nil {
+		// Log error but continue with limited functionality
+		fmt.Printf("Warning: failed to initialize multi-account sheets client: %v\n", err)
+		multiClient = &MultiAccountClient{
+			accountManager: accountManager,
+			clients:        make(map[string]*Client),
+		}
+	}
+
+	// Create original handler for backward compatibility
+	var handler *Handler
+	if defaultClient != nil {
+		handler = NewHandler(defaultClient)
+	}
+
+	return &MultiAccountHandler{
+		multiClient: multiClient,
+		handler:     handler,
+	}
+}
+
+// GetTools returns the available Sheets tools with an added account parameter
+func (h *MultiAccountHandler) GetTools() []server.Tool {
+	if h.handler == nil {
+		return []server.Tool{}
+	}
+
+	tools := h.handler.GetTools()
+
+	// Add account parameter to existing tools
+	for i := range tools {
+		if tools[i].InputSchema.Properties == nil {
+			tools[i].InputSchema.Properties = make(map[string]server.Property)
+		}
+		tools[i].InputSchema.Properties["account"] = server.Property{
+			Type:        "string",
+			Description: "Email address of the account to use (optional)",
+		}
+	}
+
+	return tools
+}
+
+// HandleToolCall handles a tool call for Sheets service with multi-account support
+func (h *MultiAccountHandler) HandleToolCall(ctx context.Context, name string, arguments json.RawMessage) (interface{}, error) {
+	// Check if account parameter is provided
+	var accountHint string
+	if arguments != nil {
+		var args map[string]interface{}
+		if err := json.Unmarshal(arguments, &args); err == nil {
+			if account, ok := args["account"].(string); ok {
+				accountHint = account
+			}
+		}
+	}
+
+	// Try to get client for the specified account (or the sole account)
+	if h.multiClient != nil {
+		client, accountUsed, err := h.multiClient.GetClientForContext(ctx, accountHint)
+		if err == nil {
+			// Create a temporary handler with the selected client
+			tempHandler := NewHandler(client)
+			result, err := tempHandler.HandleToolCall(ctx, name, arguments)
+			if err != nil {
+				return nil, err
+			}
+
+			// Add account information to result if it's a map
+			if resultMap, ok := result.(map[string]interface{}); ok {
+				resultMap["account"] = accountUsed
+			}
+
+			return result, nil
+		}
+	}
+
+	// Fall back to original handler for backward compatibility
+	if h.handler != nil {
+		return h.handler.HandleToolCall(ctx, name, arguments)
+	}
+
+	return nil, fmt.Errorf("no handler available for tool: %s", name)
+}
+
+// GetResources returns the available Sheets resources
+func (h *MultiAccountHandler) GetResources() []server.Resource {
+	if h.handler != nil {
+		return h.handler.GetResources()
+	}
+	return []server.Resource{}
+}
+
+// HandleResourceCall handles a resource call for Sheets service
+func (h *MultiAccountHandler) HandleResourceCall(ctx context.Context, uri string) (interface{}, error) {
+	if h.handler != nil {
+		return h.handler.HandleResourceCall(ctx, uri)
+	}
+	return nil, fmt.Errorf("no handler available for resource: %s", uri)
+}

--- a/sheets/multi_account.go
+++ b/sheets/multi_account.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 
@@ -31,7 +32,7 @@ func NewMultiAccountClient(ctx context.Context, accountManager *auth.AccountMana
 	for email, oauthClient := range accountManager.GetAllOAuthClients() {
 		service, err := sheets.NewService(ctx, option.WithHTTPClient(oauthClient.GetHTTPClient()))
 		if err != nil {
-			fmt.Printf("Warning: failed to create sheets service for %s: %v\n", email, err)
+			log.Printf("[WARNING] Failed to create sheets service for %s: %v\n", email, err)
 			continue
 		}
 		mac.clients[email] = &Client{service: service}
@@ -59,8 +60,14 @@ func (mac *MultiAccountClient) GetClientForContext(ctx context.Context, hint str
 			return nil, "", fmt.Errorf("failed to create sheets service: %w", err)
 		}
 
-		newClient := &Client{service: service}
 		mac.mu.Lock()
+		// Another goroutine may have created the client while we were building
+		// ours, so re-check under the write lock and keep the existing one.
+		if existing, ok := mac.clients[account.Email]; ok {
+			mac.mu.Unlock()
+			return existing, account.Email, nil
+		}
+		newClient := &Client{service: service}
 		mac.clients[account.Email] = newClient
 		mac.mu.Unlock()
 
@@ -105,7 +112,7 @@ func NewMultiAccountHandler(accountManager *auth.AccountManager, defaultClient *
 	multiClient, err := NewMultiAccountClient(ctx, accountManager)
 	if err != nil {
 		// Log error but continue with limited functionality
-		fmt.Printf("Warning: failed to initialize multi-account sheets client: %v\n", err)
+		log.Printf("[WARNING] Failed to initialize multi-account sheets client: %v\n", err)
 		multiClient = &MultiAccountClient{
 			accountManager: accountManager,
 			clients:        make(map[string]*Client),
@@ -158,8 +165,10 @@ func (h *MultiAccountHandler) HandleToolCall(ctx context.Context, name string, a
 	}
 
 	// Try to get client for the specified account (or the sole account)
+	var accountErr error
 	if h.multiClient != nil {
 		client, accountUsed, err := h.multiClient.GetClientForContext(ctx, accountHint)
+		accountErr = err
 		if err == nil {
 			// Create a temporary handler with the selected client
 			tempHandler := NewHandler(client)
@@ -180,6 +189,11 @@ func (h *MultiAccountHandler) HandleToolCall(ctx context.Context, name string, a
 	// Fall back to original handler for backward compatibility
 	if h.handler != nil {
 		return h.handler.HandleToolCall(ctx, name, arguments)
+	}
+
+	// Without a default client, surface why no account could be selected
+	if accountErr != nil {
+		return nil, accountErr
 	}
 
 	return nil, fmt.Errorf("no handler available for tool: %s", name)

--- a/sheets/multi_account_test.go
+++ b/sheets/multi_account_test.go
@@ -1,0 +1,60 @@
+package sheets
+
+import (
+	"context"
+	"testing"
+
+	"go.ngs.io/google-mcp-server/auth"
+)
+
+func newTestAccountManager(t *testing.T) *auth.AccountManager {
+	t.Helper()
+
+	// Keep the account manager away from the real home directory
+	t.Setenv("HOME", t.TempDir())
+
+	am, err := auth.NewAccountManager(context.Background(), auth.OAuthConfig{})
+	if err != nil {
+		t.Fatalf("Failed to create account manager: %v", err)
+	}
+
+	return am
+}
+
+// TestGetToolsWithoutDefaultClient covers the multi-account-only setup, where
+// no default OAuth client exists and the Sheets tools must still be listed.
+func TestGetToolsWithoutDefaultClient(t *testing.T) {
+	handler := NewMultiAccountHandler(newTestAccountManager(t), nil)
+
+	tools := handler.GetTools()
+	if len(tools) == 0 {
+		t.Fatal("Expected Sheets tools without a default client, got none")
+	}
+
+	byName := make(map[string]bool, len(tools))
+	for _, tool := range tools {
+		byName[tool.Name] = true
+	}
+	for _, name := range []string{"sheets_spreadsheet_get", "sheets_values_get", "sheets_values_update"} {
+		if !byName[name] {
+			t.Errorf("Expected tool %s to be listed", name)
+		}
+	}
+
+	if _, ok := tools[0].InputSchema.Properties["account"]; !ok {
+		t.Errorf("Expected tool %s to accept an account parameter", tools[0].Name)
+	}
+}
+
+// TestGetToolsDoesNotMutateDefaults ensures the account parameter injection
+// does not leak into the shared tool definitions.
+func TestGetToolsDoesNotMutateDefaults(t *testing.T) {
+	handler := NewMultiAccountHandler(newTestAccountManager(t), nil)
+	handler.GetTools()
+
+	for _, tool := range defaultSheetsTools() {
+		if _, ok := tool.InputSchema.Properties["account"]; ok {
+			t.Errorf("Tool %s gained an account parameter in the shared definitions", tool.Name)
+		}
+	}
+}

--- a/sheets/tools.go
+++ b/sheets/tools.go
@@ -20,6 +20,12 @@ func NewHandler(client *Client) *Handler {
 
 // GetTools returns the available Sheets tools
 func (h *Handler) GetTools() []server.Tool {
+	return defaultSheetsTools()
+}
+
+// defaultSheetsTools returns the Sheets tool definitions. It is shared by
+// Handler and MultiAccountHandler so the definitions are not maintained twice.
+func defaultSheetsTools() []server.Tool {
 	return []server.Tool{
 		{
 			Name:        "sheets_spreadsheet_get",


### PR DESCRIPTION
## Summary

Integrates two community PRs with review follow-ups:

- **#12** (@kcmadden): `supportsAllDrives` on all Drive API calls, and per-account Sheets support via a new `sheets.MultiAccountHandler`
- **#9** (@mtalcott): `full_text` search and recursive `folder_id` filtering for `drive_files_search`

**#8** (@nagumo-dawnlabs) is not merged: its Shared Drive changes are a subset of #12. Its one unique addition — the `driveId` field on Drive file responses — is picked into this branch, so #8 can be closed once this lands.

## Review follow-ups included

- `sheets.MultiAccountHandler.GetTools()` returned an empty list when no default OAuth client exists — the same bug fixed for Drive in #13. The Sheets tool definitions are now shared via `defaultSheetsTools()` so the tools stay visible in multi-account-only setups, with regression tests mirroring the Drive ones.
- Conflict resolution in `main.go` keeps the nil-client guards and warning logs from #13 while adopting #12's always-registered multi-account Sheets handler.
- `driveId` added to `ListFiles` / `GetFile` fields (from #8).

## Testing

`go test ./...`, `go vet ./...`, `gofmt -l` all clean after each merge and the follow-up commit.

Merging this PR will mark #12 and #9 as merged (their head commits are contained in this branch).