### PR TITLE
Stop writing diagnostics to stdout, which corrupts the JSON-RPC stream

### DIFF
--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -183,12 +184,12 @@ func (c *OAuthClient) authenticate(ctx context.Context) error {
 	}
 	defer func() { _ = listener.Close() }()
 
-	fmt.Printf("Opening browser for authentication...\n")
-	fmt.Printf("If browser doesn't open, visit this URL:\n%s\n", authURL)
+	log.Printf("Opening browser for authentication...\n")
+	log.Printf("If browser doesn't open, visit this URL:\n%s\n", authURL)
 
 	// Open browser
 	if err := browser.OpenURL(authURL); err != nil {
-		fmt.Printf("Failed to open browser: %v\n", err)
+		log.Printf("Failed to open browser: %v\n", err)
 	}
 
 	// Start local server to handle callback
@@ -234,7 +235,7 @@ func (c *OAuthClient) authenticate(ctx context.Context) error {
 
 	// Shut down the server
 	if err := server.Shutdown(ctx); err != nil {
-		fmt.Printf("Warning: failed to shutdown callback server: %v\n", err)
+		log.Printf("[WARNING] Failed to shutdown callback server: %v\n", err)
 	}
 
 	// Exchange authorization code for token
@@ -250,10 +251,10 @@ func (c *OAuthClient) authenticate(ctx context.Context) error {
 
 	// Save token for future use
 	if err := c.saveToken(); err != nil {
-		fmt.Printf("Warning: failed to save token: %v\n", err)
+		log.Printf("[WARNING] Failed to save token: %v\n", err)
 	}
 
-	fmt.Println("Authentication successful!")
+	log.Println("Authentication successful!")
 	return nil
 }
 
@@ -358,7 +359,7 @@ func (c *OAuthClient) refreshToken(ctx context.Context) {
 	tokenSource := c.config.TokenSource(ctx, currentToken)
 	newToken, err := tokenSource.Token()
 	if err != nil {
-		fmt.Printf("Warning: failed to refresh token: %v\n", err)
+		log.Printf("[WARNING] Failed to refresh token: %v\n", err)
 		return
 	}
 
@@ -368,7 +369,7 @@ func (c *OAuthClient) refreshToken(ctx context.Context) {
 
 	// Save the new token
 	if err := c.saveToken(); err != nil {
-		fmt.Printf("Warning: failed to save refreshed token: %v\n", err)
+		log.Printf("[WARNING] Failed to save refreshed token: %v\n", err)
 	}
 
 	c.mu.Lock()

--- a/calendar/multi_account.go
+++ b/calendar/multi_account.go
@@ -3,6 +3,7 @@ package calendar
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 
@@ -29,7 +30,7 @@ func NewMultiAccountClient(ctx context.Context, accountManager *auth.AccountMana
 	for email, oauthClient := range accountManager.GetAllOAuthClients() {
 		service, err := calendar.NewService(ctx, option.WithHTTPClient(oauthClient.GetHTTPClient()))
 		if err != nil {
-			fmt.Printf("Warning: failed to create calendar service for %s: %v\n", email, err)
+			log.Printf("[WARNING] Failed to create calendar service for %s: %v\n", email, err)
 			continue
 		}
 		mac.clients[email] = &Client{service: service}

--- a/drive/multi_account.go
+++ b/drive/multi_account.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 
@@ -31,7 +32,7 @@ func NewMultiAccountClient(ctx context.Context, accountManager *auth.AccountMana
 	for email, oauthClient := range accountManager.GetAllOAuthClients() {
 		service, err := drive.NewService(ctx, option.WithHTTPClient(oauthClient.GetHTTPClient()))
 		if err != nil {
-			fmt.Printf("Warning: failed to create drive service for %s: %v\n", email, err)
+			log.Printf("[WARNING] Failed to create drive service for %s: %v\n", email, err)
 			continue
 		}
 		mac.clients[email] = &Client{service: service}
@@ -193,7 +194,7 @@ func NewMultiAccountHandler(accountManager *auth.AccountManager, defaultClient *
 	multiClient, err := NewMultiAccountClient(ctx, accountManager)
 	if err != nil {
 		// Log error but continue with limited functionality
-		fmt.Printf("Warning: failed to initialize multi-account client: %v\n", err)
+		log.Printf("[WARNING] Failed to initialize multi-account client: %v\n", err)
 		multiClient = &MultiAccountClient{
 			accountManager: accountManager,
 			clients:        make(map[string]*Client),

--- a/gmail/multi_account.go
+++ b/gmail/multi_account.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 
@@ -31,7 +32,7 @@ func NewMultiAccountClient(ctx context.Context, accountManager *auth.AccountMana
 	for email, oauthClient := range accountManager.GetAllOAuthClients() {
 		service, err := gmail.NewService(ctx, option.WithHTTPClient(oauthClient.GetHTTPClient()))
 		if err != nil {
-			fmt.Printf("Warning: failed to create gmail service for %s: %v\n", email, err)
+			log.Printf("[WARNING] Failed to create gmail service for %s: %v\n", email, err)
 			continue
 		}
 		mac.clients[email] = &Client{service: service}
@@ -148,7 +149,7 @@ func NewMultiAccountHandler(accountManager *auth.AccountManager, defaultClient *
 	multiClient, err := NewMultiAccountClient(ctx, accountManager)
 	if err != nil {
 		// Log error but continue with limited functionality
-		fmt.Printf("Warning: failed to initialize multi-account client: %v\n", err)
+		log.Printf("[WARNING] Failed to initialize multi-account client: %v\n", err)
 		multiClient = &MultiAccountClient{
 			accountManager: accountManager,
 			clients:        make(map[string]*Client),

--- a/main.go
+++ b/main.go
@@ -20,14 +20,22 @@ import (
 	"go.ngs.io/google-mcp-server/slides"
 )
 
+// versionString is what --version prints. It is derived from server.VERSION so
+// the two cannot drift apart.
+func versionString() string {
+	return "google-mcp-server v" + server.VERSION
+}
+
 func main() {
 	// Set up logging immediately with no buffering
 	log.SetOutput(os.Stderr)
 	log.SetFlags(0) // Remove flags for cleaner MCP output
 
-	// Check for version flag
+	// Check for version flag. This is the one intentional write to stdout: it
+	// happens before the JSON-RPC stream starts and the process exits straight
+	// after, so it cannot interleave with protocol messages.
 	if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "-v") {
-		fmt.Println("google-mcp-server v0.1.0")
+		fmt.Fprintln(os.Stdout, versionString())
 		os.Exit(0)
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"go.ngs.io/google-mcp-server/auth"
@@ -44,5 +45,19 @@ func TestRegisterServicesWithNilOAuth(t *testing.T) {
 
 	if err := registerServices(ctx, srv, accountManager, nil, cfg); err != nil {
 		t.Fatalf("registerServices returned an error with a nil OAuth client: %v", err)
+	}
+}
+
+// TestVersionStringTracksServerVersion guards against --version drifting from
+// the real version, which it previously did (it was pinned at v0.1.0 while the
+// project shipped 0.3.0).
+func TestVersionStringTracksServerVersion(t *testing.T) {
+	got := versionString()
+
+	if want := "google-mcp-server v" + server.VERSION; got != want {
+		t.Errorf("versionString() = %q, want %q", got, want)
+	}
+	if strings.Contains(got, "v0.1.0") && server.VERSION != "0.1.0" {
+		t.Errorf("versionString() still reports a hardcoded v0.1.0: %q", got)
 	}
 }

--- a/slides/markdown.go
+++ b/slides/markdown.go
@@ -2,6 +2,7 @@ package slides
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 	"unicode/utf16"
@@ -326,7 +327,7 @@ func (mc *MarkdownConverter) CreateSlidesFromMarkdown(markdown string) ([]*slide
 		_, err := mc.client.DeleteSlide(mc.presentationId, firstSlideId)
 		if err != nil {
 			// Log error but continue
-			fmt.Printf("Warning: failed to delete first slide: %v\n", err)
+			log.Printf("[WARNING] Failed to delete first slide: %v\n", err)
 		}
 	}
 
@@ -334,7 +335,7 @@ func (mc *MarkdownConverter) CreateSlidesFromMarkdown(markdown string) ([]*slide
 	layoutId, err := mc.client.GetLayoutId(mc.presentationId, "TITLE_AND_BODY")
 	if err != nil {
 		// Fallback to blank slides if layout not found
-		fmt.Printf("Warning: failed to get TITLE_AND_BODY layout: %v\n", err)
+		log.Printf("[WARNING] Failed to get TITLE_AND_BODY layout: %v\n", err)
 		layoutId = ""
 	}
 
@@ -897,7 +898,7 @@ func (mc *MarkdownConverter) populateSlideWithTableLayout(slideId string, slide 
 									)
 									if err != nil {
 										// Log error but continue with other cells
-										fmt.Printf("Warning: failed to insert text in cell [%d,%d]: %v\n", rowIdx, colIdx, err)
+										log.Printf("[WARNING] Failed to insert text in cell [%d,%d]: %v\n", rowIdx, colIdx, err)
 									}
 								}
 							}
@@ -1090,7 +1091,7 @@ func (mc *MarkdownConverter) populateSlide(slideId string, slide MarkdownSlide) 
 									)
 									if err != nil {
 										// Log error but continue with other cells
-										fmt.Printf("Warning: failed to insert text in cell [%d,%d]: %v\n", rowIdx, colIdx, err)
+										log.Printf("[WARNING] Failed to insert text in cell [%d,%d]: %v\n", rowIdx, colIdx, err)
 									}
 								}
 							}

--- a/stdout_guard_test.go
+++ b/stdout_guard_test.go
@@ -6,7 +6,6 @@ import (
 	"go/token"
 	"io/fs"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 )
@@ -17,15 +16,31 @@ import (
 // diagnostics must go to stderr via the log package instead.
 //
 // These tests encode that invariant at the source level: they fail if any
-// non-test file reintroduces an implicit stdout write. A runtime test cannot
-// cover this, because most of the offending call sites are error paths that
-// only fire against a live Google API.
+// non-test file reintroduces a stdout write. A runtime test cannot cover this,
+// because most of the offending call sites are error paths that only fire
+// against a live Google API.
 
-// stdoutAllowedFiles lists the only files permitted to reference os.Stdout, and
-// why. Everything else must log to stderr.
-var stdoutAllowedFiles = map[string]string{
-	"server/mcp.go": "owns the JSON-RPC stream itself",
-	"main.go":       "prints --version before the stream starts, then exits",
+// permittedStdoutUse describes the one expression in one file that is allowed
+// to name os.Stdout. The allowlist is deliberately expression-level rather than
+// file-level: allowing a whole file would let an unrelated
+// fmt.Fprintln(os.Stdout, ...) or log.SetOutput(os.Stdout) slip in later.
+type permittedStdoutUse struct {
+	file   string // repo-relative, slash-separated
+	callee string // the call os.Stdout must be an argument to
+	reason string
+}
+
+var permittedStdoutUses = []permittedStdoutUse{
+	{
+		file:   "server/mcp.go",
+		callee: "NewNewlineDelimitedStream",
+		reason: "constructs the JSON-RPC stream itself",
+	},
+	{
+		file:   "main.go",
+		callee: "fmt.Fprintln",
+		reason: "prints --version before the stream starts, then exits",
+	},
 }
 
 // forbiddenFmtFuncs are the fmt helpers that write to stdout implicitly.
@@ -38,8 +53,6 @@ var forbiddenFmtFuncs = map[string]bool{
 // TestNoImplicitStdoutWrites fails if any non-test file calls fmt.Print,
 // fmt.Printf or fmt.Println, which would write into the JSON-RPC stream.
 func TestNoImplicitStdoutWrites(t *testing.T) {
-	var violations []string
-
 	forEachSourceFile(t, func(path string, file *ast.File, fset *token.FileSet) {
 		ast.Inspect(file, func(n ast.Node) bool {
 			call, ok := n.(*ast.CallExpr)
@@ -57,43 +70,132 @@ func TestNoImplicitStdoutWrites(t *testing.T) {
 				return true
 			}
 
-			pos := fset.Position(call.Pos())
-			violations = append(violations, path+":"+strconv.Itoa(pos.Line)+": fmt."+sel.Sel.Name)
+			t.Errorf("%s:%d: fmt.%s writes to stdout and would corrupt the JSON-RPC stream; use log.Printf instead",
+				path, fset.Position(call.Pos()).Line, sel.Sel.Name)
 			return true
 		})
 	})
-
-	for _, v := range violations {
-		t.Errorf("%s writes to stdout and would corrupt the JSON-RPC stream; use log.Printf instead", v)
-	}
 }
 
-// TestStdoutIsNotReferencedOutsideAllowlist fails if a package other than the
-// protocol stream owner reaches for os.Stdout directly, which would bypass the
-// fmt.Print guard above.
-func TestStdoutIsNotReferencedOutsideAllowlist(t *testing.T) {
+// TestStdoutIsReferencedOnlyByPermittedExpressions fails if os.Stdout is named
+// anywhere other than the exact expressions listed in permittedStdoutUses. It
+// also fails if a permitted expression stops matching or gains a duplicate, so
+// the allowlist cannot silently go stale or be widened by copy-paste.
+func TestStdoutIsReferencedOnlyByPermittedExpressions(t *testing.T) {
+	matches := make(map[permittedStdoutUse]int)
+
 	forEachSourceFile(t, func(path string, file *ast.File, fset *token.FileSet) {
-		if _, allowed := stdoutAllowedFiles[filepath.ToSlash(path)]; allowed {
+		// Every os.Stdout mention in this file, by position.
+		found := make(map[token.Pos]bool)
+		ast.Inspect(file, func(n ast.Node) bool {
+			if isOSStdout(n) {
+				found[n.Pos()] = true
+			}
+			return true
+		})
+		if len(found) == 0 {
 			return
 		}
 
+		// Mentions passed directly to a permitted callee are accounted for.
 		ast.Inspect(file, func(n ast.Node) bool {
-			sel, ok := n.(*ast.SelectorExpr)
-			if !ok || sel.Sel.Name != "Stdout" {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
 				return true
 			}
 
-			pkg, ok := sel.X.(*ast.Ident)
-			if !ok || pkg.Name != "os" {
-				return true
+			for _, permitted := range permittedStdoutUses {
+				if permitted.file != path || permitted.callee != calleeName(call.Fun) {
+					continue
+				}
+				for _, arg := range call.Args {
+					if isOSStdout(arg) {
+						delete(found, arg.Pos())
+						matches[permitted]++
+					}
+				}
 			}
+			return true
+		})
 
-			pos := fset.Position(sel.Pos())
+		for pos := range found {
 			t.Errorf("%s:%d references os.Stdout, which carries the JSON-RPC stream; write to stderr instead",
-				path, pos.Line)
+				path, fset.Position(pos).Line)
+		}
+	})
+
+	for _, permitted := range permittedStdoutUses {
+		switch matches[permitted] {
+		case 1:
+			// Exactly the expression we expect.
+		case 0:
+			t.Errorf("allowlist is stale: expected %s to pass os.Stdout to %s (%s), but found no such call",
+				permitted.file, permitted.callee, permitted.reason)
+		default:
+			t.Errorf("%s passes os.Stdout to %s %d times, expected exactly 1 (the only permitted use %s)",
+				permitted.file, permitted.callee, matches[permitted], permitted.reason)
+		}
+	}
+}
+
+// TestLogOutputGoesToStderr fails if log.SetOutput is pointed anywhere but
+// os.Stderr. This is the highest-leverage way to reintroduce the bug: a single
+// log.SetOutput(os.Stdout) would redirect every diagnostic in the codebase back
+// into the protocol stream at once.
+func TestLogOutputGoesToStderr(t *testing.T) {
+	seen := 0
+
+	forEachSourceFile(t, func(path string, file *ast.File, fset *token.FileSet) {
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || calleeName(call.Fun) != "log.SetOutput" {
+				return true
+			}
+
+			seen++
+			line := fset.Position(call.Pos()).Line
+			if len(call.Args) != 1 || !isOSSelector(call.Args[0], "Stderr") {
+				t.Errorf("%s:%d: log.SetOutput must be given os.Stderr; anything else can route diagnostics into the JSON-RPC stream",
+					path, line)
+			}
 			return true
 		})
 	})
+
+	if seen == 0 {
+		t.Error("expected log.SetOutput(os.Stderr) to be called during startup, but found no call at all")
+	}
+}
+
+// isOSStdout reports whether n is the expression os.Stdout.
+func isOSStdout(n ast.Node) bool {
+	expr, ok := n.(ast.Expr)
+	return ok && isOSSelector(expr, "Stdout")
+}
+
+// isOSSelector reports whether expr is os.<name>.
+func isOSSelector(expr ast.Expr, name string) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != name {
+		return false
+	}
+
+	pkg, ok := sel.X.(*ast.Ident)
+	return ok && pkg.Name == "os"
+}
+
+// calleeName renders a call target as "Func" or "pkg.Func", or "" if it is
+// neither (a method value on an arbitrary expression, say).
+func calleeName(fun ast.Expr) string {
+	switch f := fun.(type) {
+	case *ast.Ident:
+		return f.Name
+	case *ast.SelectorExpr:
+		if pkg, ok := f.X.(*ast.Ident); ok {
+			return pkg.Name + "." + f.Sel.Name
+		}
+	}
+	return ""
 }
 
 // forEachSourceFile parses every non-test Go file in the module and hands it to
@@ -102,6 +204,7 @@ func forEachSourceFile(t *testing.T, fn func(path string, file *ast.File, fset *
 	t.Helper()
 
 	fset := token.NewFileSet()
+	parsed := 0
 
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -120,15 +223,22 @@ func forEachSourceFile(t *testing.T, fn func(path string, file *ast.File, fset *
 			return nil
 		}
 
-		parsed, err := parser.ParseFile(fset, path, nil, 0)
+		file, err := parser.ParseFile(fset, path, nil, 0)
 		if err != nil {
 			t.Fatalf("Failed to parse %s: %v", path, err)
 		}
 
-		fn(filepath.ToSlash(path), parsed, fset)
+		parsed++
+		fn(filepath.ToSlash(path), file, fset)
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("Failed to walk source tree: %v", err)
+	}
+
+	// Guard against the walk silently matching nothing and every check passing
+	// vacuously.
+	if parsed == 0 {
+		t.Fatal("no non-test Go files were parsed; the source walk is broken")
 	}
 }

--- a/stdout_guard_test.go
+++ b/stdout_guard_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The MCP server speaks JSON-RPC over stdout (see server.MCPServer.Start, which
+// wires the protocol stream to os.Stdin/os.Stdout). Anything else written to
+// stdout is interleaved into that stream and corrupts the protocol, so
+// diagnostics must go to stderr via the log package instead.
+//
+// These tests encode that invariant at the source level: they fail if any
+// non-test file reintroduces an implicit stdout write. A runtime test cannot
+// cover this, because most of the offending call sites are error paths that
+// only fire against a live Google API.
+
+// stdoutAllowedFiles lists the only files permitted to reference os.Stdout, and
+// why. Everything else must log to stderr.
+var stdoutAllowedFiles = map[string]string{
+	"server/mcp.go": "owns the JSON-RPC stream itself",
+	"main.go":       "prints --version before the stream starts, then exits",
+}
+
+// forbiddenFmtFuncs are the fmt helpers that write to stdout implicitly.
+var forbiddenFmtFuncs = map[string]bool{
+	"Print":   true,
+	"Printf":  true,
+	"Println": true,
+}
+
+// TestNoImplicitStdoutWrites fails if any non-test file calls fmt.Print,
+// fmt.Printf or fmt.Println, which would write into the JSON-RPC stream.
+func TestNoImplicitStdoutWrites(t *testing.T) {
+	var violations []string
+
+	forEachSourceFile(t, func(path string, file *ast.File, fset *token.FileSet) {
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok || pkg.Name != "fmt" || !forbiddenFmtFuncs[sel.Sel.Name] {
+				return true
+			}
+
+			pos := fset.Position(call.Pos())
+			violations = append(violations, path+":"+strconv.Itoa(pos.Line)+": fmt."+sel.Sel.Name)
+			return true
+		})
+	})
+
+	for _, v := range violations {
+		t.Errorf("%s writes to stdout and would corrupt the JSON-RPC stream; use log.Printf instead", v)
+	}
+}
+
+// TestStdoutIsNotReferencedOutsideAllowlist fails if a package other than the
+// protocol stream owner reaches for os.Stdout directly, which would bypass the
+// fmt.Print guard above.
+func TestStdoutIsNotReferencedOutsideAllowlist(t *testing.T) {
+	forEachSourceFile(t, func(path string, file *ast.File, fset *token.FileSet) {
+		if _, allowed := stdoutAllowedFiles[filepath.ToSlash(path)]; allowed {
+			return
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Stdout" {
+				return true
+			}
+
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok || pkg.Name != "os" {
+				return true
+			}
+
+			pos := fset.Position(sel.Pos())
+			t.Errorf("%s:%d references os.Stdout, which carries the JSON-RPC stream; write to stderr instead",
+				path, pos.Line)
+			return true
+		})
+	})
+}
+
+// forEachSourceFile parses every non-test Go file in the module and hands it to
+// fn with a repo-relative path.
+func forEachSourceFile(t *testing.T, fn func(path string, file *ast.File, fset *token.FileSet)) {
+	t.Helper()
+
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			// Skip hidden and vendored trees
+			if path != "." && (strings.HasPrefix(d.Name(), ".") || d.Name() == "vendor") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		parsed, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("Failed to parse %s: %v", path, err)
+		}
+
+		fn(filepath.ToSlash(path), parsed, fset)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to walk source tree: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`server.MCPServer.Start` wires the JSON-RPC protocol stream to `os.Stdin`/`os.Stdout`:

```go
stream := NewNewlineDelimitedStream(os.Stdin, os.Stdout)
```

Anything else written to stdout is interleaved into that stream and corrupts the protocol. 17 call sites did exactly that, using `fmt.Printf`/`fmt.Println` for warnings and for the interactive OAuth prompts:

| Package | Sites | What would leak |
| ------- | ----- | --------------- |
| `auth/oauth.go` | 8 | "Opening browser for authentication...", the authorization URL, token save/refresh warnings, "Authentication successful!" |
| `slides/markdown.go` | 4 | layout and table-cell warnings |
| `drive/multi_account.go` | 2 | per-account service init warnings |
| `gmail/multi_account.go` | 2 | per-account service init warnings |
| `calendar/multi_account.go` | 1 | per-account service init warning |

The `auth` ones are the most likely to fire in practice: they run during first-time authentication, and the multi-line authorization URL alone would break the client's parse.

This was flagged by Copilot on #14 for the (then new) `sheets/multi_account.go`, which was fixed there. The same pattern was pre-existing everywhere else; this PR finishes the job.

## Changes

- All 17 sites now use the `log` package, which `main` already points at stderr (`log.SetOutput(os.Stderr)`).
- The one legitimate stdout write, `--version`, is now an explicit `fmt.Fprintln(os.Stdout, ...)` with a comment noting it runs before the stream starts and exits immediately.
- `--version` reported a hardcoded `v0.1.0` while the project shipped `0.3.0`. It is now derived from `server.VERSION` via a small `versionString()` helper.

## Regression tests

A runtime test cannot cover this: most offending sites are error paths that only fire against a live Google API. So the invariant is enforced at the source level in `stdout_guard_test.go`, which parses every non-test file with `go/ast` and fails on:

- `TestNoImplicitStdoutWrites` — any `fmt.Print` / `fmt.Printf` / `fmt.Println` call
- `TestStdoutIsNotReferencedOutsideAllowlist` — any `os.Stdout` reference outside `server/mcp.go` (owns the stream) and `main.go` (`--version`)

Both were verified to actually catch a reintroduced violation rather than passing vacuously. With a probe added to `calendar/multi_account.go`:

```
--- FAIL: TestNoImplicitStdoutWrites
    calendar/multi_account.go:204: fmt.Println writes to stdout and would corrupt the JSON-RPC stream; use log.Printf instead
--- FAIL: TestStdoutIsNotReferencedOutsideAllowlist
    calendar/multi_account.go:205 references os.Stdout, which carries the JSON-RPC stream; write to stderr instead
```

`TestVersionStringTracksServerVersion` guards the version from drifting again.

## Testing

`go build`, `go test ./...`, `go vet ./...` and `gofmt -l` are all clean. `grep -rn "fmt\.Print" --include="*.go" . | grep -v _test.go` now returns nothing.