### PR TITLE
Correct the reported version and fail releases on a version/tag mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,20 @@ jobs:
         echo "Run 'make set-version VERSION=${GITHUB_REF_NAME}' on master, then re-tag."
         exit 1
 
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: '.go-version'
+        cache: true
+
+    # The comparison above only proves the tag and the constant agree, so a
+    # matching but malformed pair (tag v01.2.3 with VERSION "01.2.3") would pass
+    # it. The shape check has to run here rather than only in the release job,
+    # because build-binaries and publish-binaries do not depend on that job and
+    # would otherwise publish assets regardless.
+    - name: Check the version constant is well formed
+      run: go test ./server/ -run 'TestVersionIsWellFormed|TestIsNumericIdentifier' -v
+
   release:
     name: Release
     needs: verify-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,34 @@ permissions:
   contents: write
 
 jobs:
+  # v0.4.0 was tagged while server/version.go still said 0.3.0, so the release
+  # shipped reporting the wrong version to every MCP client via serverInfo.
+  # Nothing is published until the tag and the constant agree.
+  verify-version:
+    name: Verify version matches tag
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Check server/version.go against the pushed tag
+      run: |
+        tag="${GITHUB_REF_NAME#v}"
+        version=$(sed -n 's/^const VERSION = "\(.*\)"$/\1/p' server/version.go)
+        if [ -z "$version" ]; then
+          echo "::error::Could not read VERSION from server/version.go"
+          exit 1
+        fi
+        if [ "$tag" = "$version" ]; then
+          echo "server/version.go VERSION ($version) matches tag ${GITHUB_REF_NAME}"
+          exit 0
+        fi
+        echo "::error::server/version.go VERSION is ${version} but the tag is ${GITHUB_REF_NAME}"
+        echo "Run 'make set-version VERSION=${GITHUB_REF_NAME}' on master, then re-tag."
+        exit 1
+
   release:
     name: Release
+    needs: verify-version
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -38,6 +64,7 @@ jobs:
 
   build-binaries:
     name: Build Binaries
+    needs: verify-version
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/server/version.go
+++ b/server/version.go
@@ -1,4 +1,4 @@
 package server
 
 // VERSION is the current version of the google-mcp-server
-const VERSION = "0.3.0"
+const VERSION = "0.4.0"

--- a/server/version_test.go
+++ b/server/version_test.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// VERSION is reported to every MCP client in the initialize handshake (see
+// serverInfo in mcp.go) and printed by --version, so a malformed value is
+// visible to users. The release job additionally checks it against the pushed
+// git tag; this test covers the shape, which is cheap to get wrong when
+// `make set-version` is run by hand.
+func TestVersionIsWellFormed(t *testing.T) {
+	if VERSION == "" {
+		t.Fatal("VERSION is empty")
+	}
+
+	if strings.HasPrefix(VERSION, "v") {
+		t.Errorf("VERSION = %q; the constant holds the bare version, the 'v' prefix belongs to the git tag only", VERSION)
+	}
+
+	parts := strings.Split(VERSION, ".")
+	if len(parts) != 3 {
+		t.Fatalf("VERSION = %q; want three dot-separated components (major.minor.patch)", VERSION)
+	}
+
+	for i, part := range parts {
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			t.Errorf("VERSION = %q; component %d (%q) is not a number", VERSION, i, part)
+			continue
+		}
+		if n < 0 {
+			t.Errorf("VERSION = %q; component %d (%d) is negative", VERSION, i, n)
+		}
+	}
+}

--- a/server/version_test.go
+++ b/server/version_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"strconv"
 	"strings"
 	"testing"
 )
@@ -26,13 +25,58 @@ func TestVersionIsWellFormed(t *testing.T) {
 	}
 
 	for i, part := range parts {
-		n, err := strconv.Atoi(part)
-		if err != nil {
-			t.Errorf("VERSION = %q; component %d (%q) is not a number", VERSION, i, part)
-			continue
-		}
-		if n < 0 {
-			t.Errorf("VERSION = %q; component %d (%d) is negative", VERSION, i, n)
+		if !isNumericIdentifier(part) {
+			t.Errorf("VERSION = %q; component %d (%q) is not a SemVer numeric identifier", VERSION, i, part)
 		}
 	}
+}
+
+// TestIsNumericIdentifier pins down the cases strconv.Atoi would wave through:
+// a sign or a leading zero makes a component invalid SemVer even though it
+// converts to an integer cleanly.
+func TestIsNumericIdentifier(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"0", true},
+		{"1", true},
+		{"10", true},
+		{"100", true},
+		{"01", false},  // leading zero
+		{"007", false}, // leading zeros
+		{"00", false},  // leading zero, not the bare "0"
+		{"+2", false},  // sign; strconv.Atoi accepts this
+		{"-3", false},  // sign; strconv.Atoi accepts this
+		{"", false},    // empty component, e.g. "1..3"
+		{" 1", false},  // whitespace
+		{"1a", false},  // trailing junk
+		{"1_0", false}, // underscore
+		{"१", false},   // non-ASCII digit
+		{"1.2", false}, // not a single component
+	}
+
+	for _, tt := range tests {
+		if got := isNumericIdentifier(tt.in); got != tt.want {
+			t.Errorf("isNumericIdentifier(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+// isNumericIdentifier reports whether s is a SemVer numeric identifier: one or
+// more ASCII digits, with no sign and no leading zero unless s is exactly "0".
+// strconv.Atoi is not enough here, since it accepts "+2", "-3" and "01".
+func isNumericIdentifier(s string) bool {
+	if s == "" {
+		return false
+	}
+
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+
+	// Leading zeros are only allowed when the identifier is exactly "0"
+	return s == "0" || s[0] != '0'
 }


### PR DESCRIPTION
## Summary

`server/version.go` said `0.3.0` while the latest released tag is `v0.4.0`. The constant is not cosmetic — it is reported to every MCP client during the initialize handshake:

```go
// server/mcp.go:229
Version: VERSION,
```

So the shipped v0.4.0 build has been telling every connected client it is 0.3.0, and `--version` agreed with it.

Confirmed against the tag itself:

```console
$ git show v0.4.0:server/version.go | grep VERSION
const VERSION = "0.3.0"
```

The v0.4.0 tag was created on 96db12f without the accompanying version bump, so only half of `make set-version` had effectively been applied.

This surfaced while triaging issues #6 and #7, whose reporters both said they were running v0.4.0 — which is how the discrepancy became visible.

## Changes

**Corrected the constant** to `0.4.0` via `make set-version VERSION=v0.4.0`, matching the latest released tag. (The target's `git tag` step failed since v0.4.0 already exists, which is expected here — this corrects a stale value rather than cutting a release. No tag was created.)

**Gated releases on the two agreeing.** A new `verify-version` job compares the pushed tag against the constant and is a `needs:` of both the GoReleaser job and `build-binaries`, so nothing is published when they disagree. `publish-binaries` is gated transitively. The failure message names the exact command to fix it:

```
::error::server/version.go VERSION is 0.3.0 but the tag is v0.4.0
Run 'make set-version VERSION=v0.4.0' on master, then re-tag.
```

I ran the check's script against three cases rather than assuming it works:

| Case | Result |
| ---- | ------ |
| tag `v0.4.0`, VERSION `0.4.0` | passes |
| tag `v0.5.0`, VERSION `0.4.0` | fails |
| tag `v0.4.0`, VERSION `0.3.0` — the actual v0.4.0 incident | fails |

**Added `TestVersionIsWellFormed`** covering the shape of the constant (non-empty, no `v` prefix, three numeric components), since `make set-version` is run by hand and the CI check only fires at tag time.

## Note for the next release

`master` now contains #13, #14 and #15 on top of v0.4.0, so the constant will move again at the next `make set-version VERSION=v0.5.0` — which will now be enforced rather than assumed.

Worth flagging separately: `make set-version` commits the version bump *before* creating the tag, so a failure at the tag step (as happened here) leaves the commit behind with no tag. Not changed in this PR.

## Testing

`go build`, `go test ./...`, `go vet ./...` and `gofmt -l` are clean. `go run . --version` now prints `google-mcp-server v0.4.0`.