### PR TITLE
Stop slides_markdown_update from emptying the deck, and cap retries

### DIFF
--- a/slides/client.go
+++ b/slides/client.go
@@ -14,8 +14,11 @@ import (
 	"google.golang.org/api/slides/v1"
 )
 
-const (
-	maxRetries       = 10
+const maxRetries = 10
+
+// Backoff durations are variables rather than constants so tests can shorten
+// them; nothing outside tests reassigns them.
+var (
 	initialBackoff   = 5 * time.Second
 	rateLimitBackoff = 60 * time.Second // Wait for quota reset on 429
 )
@@ -894,9 +897,7 @@ func (c *Client) BatchUpdate(presentationId string, requests []*slides.Request) 
 	}
 
 	return doWithRetry(func() (*slides.BatchUpdatePresentationResponse, error) {
-		return doWithRetry(func() (*slides.BatchUpdatePresentationResponse, error) {
-			return c.service.Presentations.BatchUpdate(presentationId, req).Do()
-		})
+		return c.service.Presentations.BatchUpdate(presentationId, req).Do()
 	})
 }
 

--- a/slides/markdown.go
+++ b/slides/markdown.go
@@ -346,6 +346,9 @@ func (mc *MarkdownConverter) CreateSlidesFromMarkdown(markdown string) ([]*slide
 // of the presentation and returns their IDs. It never deletes anything, so a
 // caller replacing a deck can keep the old slides until the new ones are
 // safely in place.
+//
+// On failure it returns the slides it did manage to create, so the caller can
+// clean them up rather than leaving them stranded in the presentation.
 func (mc *MarkdownConverter) appendSlidesFromMarkdown(markdown string) ([]string, error) {
 	parsedSlides := mc.ParseMarkdown(markdown)
 	createdSlideIds := make([]string, 0, len(parsedSlides))
@@ -428,14 +431,14 @@ func (mc *MarkdownConverter) appendSlidesFromMarkdown(markdown string) ([]string
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("failed to create slide %d: %w", i+1, err)
+			return createdSlideIds, fmt.Errorf("failed to create slide %d: %w", i+1, err)
 		}
 
 		var slideId string
 		if len(resp.Replies) > 0 && resp.Replies[0].CreateSlide != nil {
 			slideId = resp.Replies[0].CreateSlide.ObjectId
 		} else {
-			return nil, fmt.Errorf("failed to get slide ID for slide %d", i+1)
+			return createdSlideIds, fmt.Errorf("failed to get slide ID for slide %d", i+1)
 		}
 		createdSlideIds = append(createdSlideIds, slideId)
 
@@ -457,7 +460,7 @@ func (mc *MarkdownConverter) appendSlidesFromMarkdown(markdown string) ([]string
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("failed to populate slide %d: %w", i+1, err)
+			return createdSlideIds, fmt.Errorf("failed to populate slide %d: %w", i+1, err)
 		}
 	}
 
@@ -1141,6 +1144,11 @@ func (mc *MarkdownConverter) UpdateSlidesFromMarkdown(markdown string) error {
 
 	createdSlideIds, err := mc.appendSlidesFromMarkdown(markdown)
 	if err != nil {
+		// Roll back the half-built replacement. Without this the user is left
+		// with their original deck plus a run of partial slides, and each retry
+		// strands another run.
+		mc.removePartialSlides(createdSlideIds)
+
 		return fmt.Errorf("failed to build the new slides, so the existing %d were left in place: %w",
 			len(obsoleteSlideIds), err)
 	}
@@ -1160,4 +1168,16 @@ func (mc *MarkdownConverter) UpdateSlidesFromMarkdown(markdown string) error {
 	}
 
 	return nil
+}
+
+// removePartialSlides deletes slides left behind by a failed rebuild. It is
+// best effort: the caller is already returning the error that caused the
+// rollback, and a cleanup failure should not replace it.
+func (mc *MarkdownConverter) removePartialSlides(slideIds []string) {
+	for _, slideId := range slideIds {
+		if _, err := mc.client.DeleteSlide(mc.presentationId, slideId); err != nil {
+			log.Printf("[WARNING] Failed to remove partially built slide %s; it may need deleting by hand: %v\n",
+				slideId, err)
+		}
+	}
 }

--- a/slides/markdown.go
+++ b/slides/markdown.go
@@ -313,8 +313,6 @@ func (mc *MarkdownConverter) estimateLineHeight(line string) float64 {
 }
 
 func (mc *MarkdownConverter) CreateSlidesFromMarkdown(markdown string) ([]*slides.Page, error) {
-	parsedSlides := mc.ParseMarkdown(markdown)
-
 	// Get current presentation to check existing slides
 	presentation, err := mc.client.GetPresentation(mc.presentationId)
 	if err != nil {
@@ -330,6 +328,27 @@ func (mc *MarkdownConverter) CreateSlidesFromMarkdown(markdown string) ([]*slide
 			log.Printf("[WARNING] Failed to delete first slide: %v\n", err)
 		}
 	}
+
+	if _, err := mc.appendSlidesFromMarkdown(markdown); err != nil {
+		return nil, err
+	}
+
+	// Return updated presentation slides
+	updatedPresentation, err := mc.client.GetPresentation(mc.presentationId)
+	if err != nil {
+		return nil, err
+	}
+
+	return updatedPresentation.Slides, nil
+}
+
+// appendSlidesFromMarkdown appends the slides described by markdown to the end
+// of the presentation and returns their IDs. It never deletes anything, so a
+// caller replacing a deck can keep the old slides until the new ones are
+// safely in place.
+func (mc *MarkdownConverter) appendSlidesFromMarkdown(markdown string) ([]string, error) {
+	parsedSlides := mc.ParseMarkdown(markdown)
+	createdSlideIds := make([]string, 0, len(parsedSlides))
 
 	// Get the TITLE_AND_BODY layout ID
 	layoutId, err := mc.client.GetLayoutId(mc.presentationId, "TITLE_AND_BODY")
@@ -418,6 +437,7 @@ func (mc *MarkdownConverter) CreateSlidesFromMarkdown(markdown string) ([]*slide
 		} else {
 			return nil, fmt.Errorf("failed to get slide ID for slide %d", i+1)
 		}
+		createdSlideIds = append(createdSlideIds, slideId)
 
 		// Populate slide based on layout type and content
 		if useLayoutBased {
@@ -441,13 +461,7 @@ func (mc *MarkdownConverter) CreateSlidesFromMarkdown(markdown string) ([]*slide
 		}
 	}
 
-	// Return updated presentation slides
-	updatedPresentation, err := mc.client.GetPresentation(mc.presentationId)
-	if err != nil {
-		return nil, err
-	}
-
-	return updatedPresentation.Slides, nil
+	return createdSlideIds, nil
 }
 
 // populateSlideWithLayout populates a slide that uses a predefined layout
@@ -1107,24 +1121,43 @@ func (mc *MarkdownConverter) populateSlide(slideId string, slide MarkdownSlide) 
 	return nil
 }
 
+// UpdateSlidesFromMarkdown replaces the deck's contents with the slides
+// described by markdown.
+//
+// The new slides are appended first and the previous ones are removed only once
+// every new slide is in place. Deleting first, as this used to, meant that a
+// failure partway through the rebuild — a rate limit on a large deck, most
+// likely — left the user with an empty presentation and no way back.
 func (mc *MarkdownConverter) UpdateSlidesFromMarkdown(markdown string) error {
-	// Get current presentation
 	presentation, err := mc.client.GetPresentation(mc.presentationId)
 	if err != nil {
 		return err
 	}
 
-	// Delete all existing slides except the first one
-	if len(presentation.Slides) > 1 {
-		for i := 1; i < len(presentation.Slides); i++ {
-			_, err := mc.client.DeleteSlide(mc.presentationId, presentation.Slides[i].ObjectId)
-			if err != nil {
-				return err
-			}
+	obsoleteSlideIds := make([]string, 0, len(presentation.Slides))
+	for _, slide := range presentation.Slides {
+		obsoleteSlideIds = append(obsoleteSlideIds, slide.ObjectId)
+	}
+
+	createdSlideIds, err := mc.appendSlidesFromMarkdown(markdown)
+	if err != nil {
+		return fmt.Errorf("failed to build the new slides, so the existing %d were left in place: %w",
+			len(obsoleteSlideIds), err)
+	}
+
+	// Removing every slide would leave a presentation the API cannot represent,
+	// and would discard the user's deck in exchange for nothing.
+	if len(createdSlideIds) == 0 {
+		return fmt.Errorf("markdown produced no slides, so the existing %d were left in place",
+			len(obsoleteSlideIds))
+	}
+
+	for _, slideId := range obsoleteSlideIds {
+		if _, err := mc.client.DeleteSlide(mc.presentationId, slideId); err != nil {
+			return fmt.Errorf("created %d new slides but failed to remove the previous slide %s: %w",
+				len(createdSlideIds), slideId, err)
 		}
 	}
 
-	// Create new slides from markdown
-	_, err = mc.CreateSlidesFromMarkdown(markdown)
-	return err
+	return nil
 }

--- a/slides/update_atomicity_test.go
+++ b/slides/update_atomicity_test.go
@@ -22,6 +22,9 @@ type fakeSlidesAPI struct {
 	requests   []string       // request kinds in the order they were issued
 	nextID     int
 	failCreate bool // fail any batch containing a createSlide
+	// failCreateAfter, when non-zero, lets that many slides be created before
+	// failing, so tests can exercise a rebuild that dies partway through
+	failCreateAfter int
 }
 
 func (f *fakeSlidesAPI) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -61,6 +64,10 @@ func (f *fakeSlidesAPI) handleBatchUpdate(req *http.Request) (*http.Response, er
 		switch {
 		case r.CreateSlide != nil:
 			f.requests = append(f.requests, "createSlide")
+			if f.failCreateAfter > 0 && f.count("createSlide") > f.failCreateAfter {
+				return jsonResponse(http.StatusInternalServerError,
+					map[string]any{"error": map[string]any{"code": 500, "message": "boom"}})
+			}
 			if f.failCreate {
 				return jsonResponse(http.StatusInternalServerError,
 					map[string]any{"error": map[string]any{"code": 500, "message": "boom"}})
@@ -223,6 +230,40 @@ func TestUpdateKeepsExistingSlidesWhenCreationFails(t *testing.T) {
 	}
 	if got := fake.slideIDs(); len(got) != len(before) {
 		t.Errorf("deck has %d slides after a failed update, want the original %d", len(got), len(before))
+	}
+}
+
+// TestUpdateRemovesPartiallyBuiltSlidesOnFailure covers a rebuild that dies
+// after some slides already exist. Keeping the original deck is not enough on
+// its own: the half-built replacement has to go too, or the user is left with
+// both decks interleaved and every retry strands another run of orphans.
+func TestUpdateRemovesPartiallyBuiltSlidesOnFailure(t *testing.T) {
+	mc, fake := newFakeConverter(t, 3)
+	before := fake.slideIDs()
+	fake.failCreateAfter = 1 // first slide succeeds, the second does not
+
+	if err := mc.UpdateSlidesFromMarkdown(twoSlideMarkdown); err == nil {
+		t.Fatal("expected an error when the rebuild fails partway")
+	}
+
+	if got := fake.slideIDs(); len(got) != len(before) {
+		t.Errorf("deck has %d slides after a partial failure, want the original %d; "+
+			"orphaned slides from the failed rebuild were left behind", len(got), len(before))
+	}
+	for i, id := range fake.slideIDs() {
+		if i < len(before) && id != before[i] {
+			t.Errorf("slide %d is %s, want the original %s", i, id, before[i])
+		}
+	}
+
+	// Retrying must not accumulate orphans either
+	fake.failCreateAfter = 1
+	fake.requests = nil
+	if err := mc.UpdateSlidesFromMarkdown(twoSlideMarkdown); err == nil {
+		t.Fatal("expected an error on the retry as well")
+	}
+	if got := fake.slideIDs(); len(got) != len(before) {
+		t.Errorf("deck grew to %d slides after retrying a failing update, want %d", len(got), len(before))
 	}
 }
 

--- a/slides/update_atomicity_test.go
+++ b/slides/update_atomicity_test.go
@@ -1,0 +1,279 @@
+package slides
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/api/slides/v1"
+)
+
+// fakeSlidesAPI is a minimal stand-in for the two Slides endpoints this package
+// uses: presentations.get and presentations.batchUpdate. It keeps enough state
+// that a deck can actually be built against it, and records the order of the
+// requests so tests can assert on sequencing.
+type fakeSlidesAPI struct {
+	slides     []*slides.Page // current deck, in order
+	requests   []string       // request kinds in the order they were issued
+	nextID     int
+	failCreate bool // fail any batch containing a createSlide
+}
+
+func (f *fakeSlidesAPI) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.Path, ":batchUpdate") {
+		return f.handleBatchUpdate(req)
+	}
+	return f.handleGet()
+}
+
+func (f *fakeSlidesAPI) handleGet() (*http.Response, error) {
+	f.requests = append(f.requests, "get")
+
+	return jsonResponse(http.StatusOK, &slides.Presentation{
+		PresentationId: "test-presentation",
+		Slides:         f.slides,
+		Layouts: []*slides.Page{
+			{ObjectId: "layout-title-body", LayoutProperties: &slides.LayoutProperties{Name: "TITLE_AND_BODY"}},
+			{ObjectId: "layout-title", LayoutProperties: &slides.LayoutProperties{Name: "TITLE"}},
+			{ObjectId: "layout-title-only", LayoutProperties: &slides.LayoutProperties{Name: "TITLE_ONLY"}},
+		},
+	})
+}
+
+func (f *fakeSlidesAPI) handleBatchUpdate(req *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsed slides.BatchUpdatePresentationRequest
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, err
+	}
+
+	replies := make([]*slides.Response, 0, len(parsed.Requests))
+	for _, r := range parsed.Requests {
+		switch {
+		case r.CreateSlide != nil:
+			f.requests = append(f.requests, "createSlide")
+			if f.failCreate {
+				return jsonResponse(http.StatusInternalServerError,
+					map[string]any{"error": map[string]any{"code": 500, "message": "boom"}})
+			}
+			replies = append(replies, &slides.Response{CreateSlide: &slides.CreateSlideResponse{
+				ObjectId: f.addSlide(),
+			}})
+
+		case r.DeleteObject != nil:
+			f.requests = append(f.requests, "deleteObject")
+			f.removeSlide(r.DeleteObject.ObjectId)
+			replies = append(replies, &slides.Response{})
+
+		default:
+			// insertText, deleteText, formatting and so on: accepted as-is
+			f.requests = append(f.requests, "other")
+			replies = append(replies, &slides.Response{})
+		}
+	}
+
+	return jsonResponse(http.StatusOK, &slides.BatchUpdatePresentationResponse{Replies: replies})
+}
+
+// addSlide appends a slide carrying the title and body placeholders the
+// populate step looks for, and returns its ID.
+func (f *fakeSlidesAPI) addSlide() string {
+	f.nextID++
+	id := "slide-" + strconv.Itoa(f.nextID)
+
+	f.slides = append(f.slides, &slides.Page{
+		ObjectId: id,
+		PageElements: []*slides.PageElement{
+			{ObjectId: id + "-title", Shape: &slides.Shape{Placeholder: &slides.Placeholder{Type: "TITLE"}}},
+			{ObjectId: id + "-body", Shape: &slides.Shape{Placeholder: &slides.Placeholder{Type: "BODY"}}},
+		},
+	})
+
+	return id
+}
+
+func (f *fakeSlidesAPI) removeSlide(id string) {
+	kept := f.slides[:0]
+	for _, s := range f.slides {
+		if s.ObjectId != id {
+			kept = append(kept, s)
+		}
+	}
+	f.slides = kept
+}
+
+func (f *fakeSlidesAPI) slideIDs() []string {
+	ids := make([]string, 0, len(f.slides))
+	for _, s := range f.slides {
+		ids = append(ids, s.ObjectId)
+	}
+	return ids
+}
+
+func (f *fakeSlidesAPI) count(kind string) int {
+	n := 0
+	for _, r := range f.requests {
+		if r == kind {
+			n++
+		}
+	}
+	return n
+}
+
+func jsonResponse(status int, payload any) (*http.Response, error) {
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(string(encoded))),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}, nil
+}
+
+// newFakeConverter wires a MarkdownConverter to a fake API pre-loaded with the
+// given number of existing slides.
+func newFakeConverter(t *testing.T, existingSlides int) (*MarkdownConverter, *fakeSlidesAPI) {
+	t.Helper()
+
+	fake := &fakeSlidesAPI{}
+	for i := 0; i < existingSlides; i++ {
+		fake.addSlide()
+	}
+	// Requests made while seeding are setup, not part of what we assert on
+	fake.requests = nil
+
+	client, err := NewClient(context.Background(), &http.Client{Transport: fake})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	return NewMarkdownConverter(client, "test-presentation"), fake
+}
+
+const twoSlideMarkdown = "# First\n\nBody one\n\n---\n\n# Second\n\nBody two\n"
+
+// TestUpdateCreatesBeforeDeleting pins the ordering: every new slide must exist
+// before any old slide is removed, so an interrupted rebuild never empties the
+// deck.
+func TestUpdateCreatesBeforeDeleting(t *testing.T) {
+	mc, fake := newFakeConverter(t, 3)
+	before := fake.slideIDs()
+
+	if err := mc.UpdateSlidesFromMarkdown(twoSlideMarkdown); err != nil {
+		t.Fatalf("UpdateSlidesFromMarkdown() error = %v", err)
+	}
+
+	lastCreate, firstDelete := -1, -1
+	for i, r := range fake.requests {
+		if r == "createSlide" {
+			lastCreate = i
+		}
+		if r == "deleteObject" && firstDelete == -1 {
+			firstDelete = i
+		}
+	}
+
+	if lastCreate == -1 || firstDelete == -1 {
+		t.Fatalf("expected both creates and deletes, got %v", fake.requests)
+	}
+	if firstDelete < lastCreate {
+		t.Errorf("a slide was deleted at step %d before the last slide was created at step %d; "+
+			"an interrupted rebuild would lose the deck", firstDelete, lastCreate)
+	}
+
+	// The old slides are gone and only the new ones remain
+	for _, old := range before {
+		for _, remaining := range fake.slideIDs() {
+			if old == remaining {
+				t.Errorf("old slide %s survived the update", old)
+			}
+		}
+	}
+	if got := len(fake.slideIDs()); got != 2 {
+		t.Errorf("deck has %d slides after update, want 2", got)
+	}
+}
+
+// TestUpdateKeepsExistingSlidesWhenCreationFails is the data-loss regression:
+// the old implementation deleted first, so a failure here left nothing behind.
+func TestUpdateKeepsExistingSlidesWhenCreationFails(t *testing.T) {
+	mc, fake := newFakeConverter(t, 3)
+	before := fake.slideIDs()
+	fake.failCreate = true
+
+	err := mc.UpdateSlidesFromMarkdown(twoSlideMarkdown)
+	if err == nil {
+		t.Fatal("expected an error when slide creation fails")
+	}
+
+	if n := fake.count("deleteObject"); n != 0 {
+		t.Errorf("%d slides were deleted despite creation failing; the deck must be left intact", n)
+	}
+	if got := fake.slideIDs(); len(got) != len(before) {
+		t.Errorf("deck has %d slides after a failed update, want the original %d", len(got), len(before))
+	}
+}
+
+// TestUpdateRefusesToEmptyTheDeck covers markdown that yields no slides, which
+// would otherwise delete everything and put nothing back.
+func TestUpdateRefusesToEmptyTheDeck(t *testing.T) {
+	mc, fake := newFakeConverter(t, 3)
+
+	err := mc.UpdateSlidesFromMarkdown("   \n\n")
+	if err == nil {
+		t.Fatal("expected an error when the markdown produces no slides")
+	}
+
+	if n := fake.count("deleteObject"); n != 0 {
+		t.Errorf("%d slides were deleted for markdown that produced none", n)
+	}
+	if got := len(fake.slideIDs()); got != 3 {
+		t.Errorf("deck has %d slides, want the original 3", got)
+	}
+}
+
+// TestBatchUpdateRetriesAreNotNested guards the retry budget. BatchUpdate used
+// to wrap doWithRetry in doWithRetry, turning maxRetries into maxRetries^2 —
+// up to 100 attempts against an API that was already rate limiting.
+func TestBatchUpdateRetriesAreNotNested(t *testing.T) {
+	restoreInitial, restoreRateLimit := initialBackoff, rateLimitBackoff
+	initialBackoff, rateLimitBackoff = time.Millisecond, time.Millisecond
+	t.Cleanup(func() { initialBackoff, rateLimitBackoff = restoreInitial, restoreRateLimit })
+
+	attempts := 0
+	transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		return jsonResponse(http.StatusTooManyRequests,
+			map[string]any{"error": map[string]any{"code": 429, "message": "rateLimitExceeded"}})
+	})
+
+	client, err := NewClient(context.Background(), &http.Client{Transport: transport})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	if _, err := client.BatchUpdate("test-presentation", []*slides.Request{{}}); err == nil {
+		t.Fatal("expected an error when the API keeps returning 429")
+	}
+
+	if attempts != maxRetries {
+		t.Errorf("BatchUpdate made %d attempts, want %d; nested retries multiply the budget "+
+			"and hammer an API that is already rate limiting", attempts, maxRetries)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }


### PR DESCRIPTION
## Summary

Groundwork for #5. Two defects sit behind the rate limiting reported there, and both are worth fixing before any diffing work — one of them can destroy a user's presentation.

### 1. A failed update leaves an empty presentation

`UpdateSlidesFromMarkdown` deleted every existing slide *before* building the replacements:

```go
// delete slides 1..n
// then CreateSlidesFromMarkdown, which deletes slide 0 and rebuilds
```

If the rebuild failed partway, the deck was already gone. On a large presentation that failure is not hypothetical: the rebuild is precisely where the rate limit hits, which is what #5 describes. A 45-slide deck could be destroyed by a quota error.

The slide-building loop is now factored out as `appendSlidesFromMarkdown`, which only appends and returns the new slide IDs. `UpdateSlidesFromMarkdown` records the existing slide IDs, builds the new deck, and removes the old slides only once every new one is in place. A failure now returns an error with the old deck untouched.

Markdown that parses to zero slides is also refused rather than deleting everything and putting nothing back.

`CreateSlidesFromMarkdown` keeps its existing behaviour (drop the default title slide, then build) and now shares the same loop.

### 2. Nested retries multiply the retry budget

```go
return doWithRetry(func() (...) {
    return doWithRetry(func() (...) {   // <-- inner
        return c.service.Presentations.BatchUpdate(presentationId, req).Do()
    })
})
```

With `maxRetries = 10` this is up to **100 attempts**, and the first retry at each level waits 60s. So a rate-limited batch could hammer the API for over an hour — making the exact symptom in #5 worse. The inner call is removed.

The backoff durations become `var` instead of `const` so tests can shorten them. Nothing outside tests reassigns them.

## Testing

The tests drive a small stateful fake of the two Slides endpoints this package uses (`presentations.get`, `presentations.batchUpdate`), which is enough to build a real deck and record the order requests are issued in.

Each test was checked against the pre-fix code rather than assumed to be meaningful:

| Test | Against the old code |
| ---- | -------------------- |
| `TestUpdateCreatesBeforeDeleting` | fails — a delete precedes the last create |
| `TestUpdateKeepsExistingSlidesWhenCreationFails` | fails — slides deleted despite the failure |
| `TestUpdateRefusesToEmptyTheDeck` | fails — deletes everything for empty markdown |
| `TestBatchUpdateRetriesAreNotNested` | fails — reports 100 attempts, want 10 |

`go build`, `go test ./...`, `go vet ./...` and `gofmt -l` are clean.

## What this does not do

It does not reduce the number of API calls, which is the root cause of the rate limiting. Building a slide currently costs 6-7 sequential calls (including a full `GetPresentation` per slide to locate placeholders), so a 45-slide deck is ~300 calls against a 60/min quota.

That is addressed separately by batching, using `CreateSlideRequest.placeholderIdMappings` to assign placeholder IDs up front and collapsing create + populate into a single `batchUpdate`. Design to follow.