### PR TITLE
Build a deck in one batchUpdate instead of ~300 calls

### DIFF
--- a/slides/batch_test.go
+++ b/slides/batch_test.go
@@ -1,0 +1,300 @@
+package slides
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// buildMarkdownDeck returns markdown for n slides, each with a title and a
+// couple of bullets.
+func buildMarkdownDeck(n int) string {
+	var sections []string
+	for i := 1; i <= n; i++ {
+		sections = append(sections, fmt.Sprintf("# Slide %d\n\n- first point\n- second point\n", i))
+	}
+	return strings.Join(sections, "\n---\n\n")
+}
+
+// TestDeckIsBuiltInOneBatch is the regression that motivated batching: a deck
+// used to cost six to nine calls per slide, so a 45-slide deck ran head-first
+// into the 60-requests-per-minute quota.
+func TestDeckIsBuiltInOneBatch(t *testing.T) {
+	const slideCount = 45
+
+	mc, fake := newFakeConverter(t, 0)
+
+	created, err := mc.appendSlidesFromMarkdown(buildMarkdownDeck(slideCount))
+	if err != nil {
+		t.Fatalf("appendSlidesFromMarkdown() error = %v", err)
+	}
+
+	if len(created) != slideCount {
+		t.Fatalf("built %d slides, want %d", len(created), slideCount)
+	}
+	if fake.count("createSlide") != slideCount {
+		t.Errorf("issued %d createSlide requests, want %d", fake.count("createSlide"), slideCount)
+	}
+
+	if fake.batches > 2 {
+		t.Errorf("a %d-slide deck took %d batchUpdate calls, want at most 2; "+
+			"the whole point of batching is that the deck is one round trip",
+			slideCount, fake.batches)
+	}
+
+	// The layouts carry every placeholder ID the build needs, so one fetch is
+	// enough. A fetch per slide is also O(n^2) in bytes as the deck grows.
+	if got := fake.count("get"); got != 1 {
+		t.Errorf("fetched the presentation %d times while building %d slides, want 1",
+			got, slideCount)
+	}
+}
+
+// TestBuildEmitsNoDeleteTextForFreshSlides guards a batching-specific hazard:
+// placeholders on a slide created in the same batch are empty, and deleting
+// text from an empty shape fails the entire batch rather than being ignorable
+// the way it was when each call stood alone.
+// TestUpdateOfExistingDeckStaysWithinAFewCalls measures the whole user-facing
+// operation rather than construction alone. Building the new slides in one
+// batch is only half of an update: tearing the old deck down one slide per call
+// put a 45-slide replacement back at 46 calls against a 60/min quota, which is
+// the situation reported in #5.
+func TestUpdateOfExistingDeckStaysWithinAFewCalls(t *testing.T) {
+	const slideCount = 45
+
+	for _, existing := range []int{1, slideCount} {
+		t.Run(fmt.Sprintf("replacing%dslides", existing), func(t *testing.T) {
+			mc, fake := newFakeConverter(t, existing)
+
+			if err := mc.UpdateSlidesFromMarkdown(buildMarkdownDeck(slideCount)); err != nil {
+				t.Fatalf("UpdateSlidesFromMarkdown() error = %v", err)
+			}
+
+			if fake.batches > 2 {
+				t.Errorf("replacing a %d-slide deck took %d batchUpdate calls, want at most 2; "+
+					"deleting the old slides one call at a time undoes the batching",
+					existing, fake.batches)
+			}
+			if got := fake.count("get"); got > 2 {
+				t.Errorf("fetched the presentation %d times, want at most 2", got)
+			}
+			if got := len(fake.slideIDs()); got != slideCount {
+				t.Errorf("deck ended with %d slides, want %d", got, slideCount)
+			}
+		})
+	}
+}
+
+func TestBuildEmitsNoDeleteTextForFreshSlides(t *testing.T) {
+	mc, fake := newFakeConverter(t, 0)
+
+	if _, err := mc.appendSlidesFromMarkdown(buildMarkdownDeck(3)); err != nil {
+		t.Fatalf("appendSlidesFromMarkdown() error = %v", err)
+	}
+
+	for _, kind := range fake.requests {
+		if kind == "deleteText" {
+			t.Fatal("the build deleted text from a placeholder it had just created; " +
+				"in a batch that fails the whole deck")
+		}
+	}
+}
+
+// TestLayoutPathsProduceTheExpectedContent checks each layout path still puts
+// the same text in the same kind of placeholder as the per-call version did.
+func TestLayoutPathsProduceTheExpectedContent(t *testing.T) {
+	tests := []struct {
+		name     string
+		markdown string
+		check    func(t *testing.T, fake *fakeSlidesAPI)
+	}{
+		{
+			name:     "TITLE",
+			markdown: "# Deck title\n\n## A subtitle\n",
+			check: func(t *testing.T, fake *fakeSlidesAPI) {
+				if got := fake.placeholderText(0, "CENTERED_TITLE"); got != "Deck title" {
+					t.Errorf("title placeholder holds %q, want %q", got, "Deck title")
+				}
+				if got := fake.placeholderText(0, "SUBTITLE"); got != "A subtitle" {
+					t.Errorf("subtitle placeholder holds %q, want %q", got, "A subtitle")
+				}
+			},
+		},
+		{
+			name:     "TITLE_AND_BODY",
+			markdown: "# Heading\n\n- one\n- two\n",
+			check: func(t *testing.T, fake *fakeSlidesAPI) {
+				if got := fake.placeholderText(0, "TITLE"); got != "Heading" {
+					t.Errorf("title placeholder holds %q, want %q", got, "Heading")
+				}
+				if got := fake.placeholderText(0, "BODY"); got != "• one\n• two" {
+					t.Errorf("body placeholder holds %q, want %q", got, "• one\n• two")
+				}
+			},
+		},
+		{
+			name:     "TITLE_ONLY with a table",
+			markdown: "# Numbers\n\n| A | B |\n| --- | --- |\n| 1 | 2 |\n",
+			check: func(t *testing.T, fake *fakeSlidesAPI) {
+				if got := fake.placeholderText(0, "TITLE"); got != "Numbers" {
+					t.Errorf("title placeholder holds %q, want %q", got, "Numbers")
+				}
+				if len(fake.tableIds) != 1 {
+					t.Fatalf("created %d tables, want 1", len(fake.tableIds))
+				}
+
+				tableId := fake.tableIds[0]
+				want := map[string]string{
+					fmt.Sprintf("%s[0,0]", tableId): "A",
+					fmt.Sprintf("%s[0,1]", tableId): "B",
+					fmt.Sprintf("%s[1,0]", tableId): "1",
+					fmt.Sprintf("%s[1,1]", tableId): "2",
+				}
+				for key, wantText := range want {
+					if got := fake.text[key]; got != wantText {
+						t.Errorf("cell %s holds %q, want %q", key, got, wantText)
+					}
+				}
+			},
+		},
+		{
+			name:     "TITLE_ONLY with an image",
+			markdown: "# Picture\n\n![a caption](https://example.com/image.png)\n",
+			check: func(t *testing.T, fake *fakeSlidesAPI) {
+				if got := fake.placeholderText(0, "TITLE"); got != "Picture" {
+					t.Errorf("title placeholder holds %q, want %q", got, "Picture")
+				}
+				if got := fake.count("createImage"); got != 1 {
+					t.Errorf("issued %d createImage requests, want 1", got)
+				}
+				// The alt text becomes a caption text box under the image
+				if got := fake.count("createShape"); got != 1 {
+					t.Errorf("issued %d createShape requests, want 1 for the caption", got)
+				}
+			},
+		},
+		{
+			name:     "code block in the body",
+			markdown: "# Example\n\nSome prose\n\n```\nfmt.Println()\n```\n",
+			check: func(t *testing.T, fake *fakeSlidesAPI) {
+				if got := fake.placeholderText(0, "TITLE"); got != "Example" {
+					t.Errorf("title placeholder holds %q, want %q", got, "Example")
+				}
+				body := fake.placeholderText(0, "BODY")
+				if !strings.Contains(body, "fmt.Println()") {
+					t.Errorf("body placeholder holds %q, want it to contain the code", body)
+				}
+				// The code range is restyled to Courier New in the same batch
+				styledBody := false
+				for _, styling := range fake.styled {
+					if styling.fontFamily == "Courier New" {
+						styledBody = true
+					}
+				}
+				if !styledBody {
+					t.Error("the code block was never restyled to Courier New")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc, fake := newFakeConverter(t, 0)
+
+			if _, err := mc.appendSlidesFromMarkdown(tt.markdown); err != nil {
+				t.Fatalf("appendSlidesFromMarkdown() error = %v", err)
+			}
+			if len(fake.slides) != 1 {
+				t.Fatalf("built %d slides, want 1", len(fake.slides))
+			}
+
+			tt.check(t, fake)
+		})
+	}
+}
+
+// TestBuildChunksLargeDecks covers the safety valve: past the flush threshold
+// the deck is split across batches rather than sent as one enormous request.
+func TestBuildChunksLargeDecks(t *testing.T) {
+	const slideCount = 10
+
+	// Each slide costs more than one request, so a threshold of 1 flushes at
+	// every slide boundary
+	withMaxRequestsPerBatch(t, 1)
+
+	mc, fake := newFakeConverter(t, 0)
+
+	created, err := mc.appendSlidesFromMarkdown(buildMarkdownDeck(slideCount))
+	if err != nil {
+		t.Fatalf("appendSlidesFromMarkdown() error = %v", err)
+	}
+
+	if len(created) != slideCount {
+		t.Fatalf("built %d slides, want %d", len(created), slideCount)
+	}
+	if fake.batches != slideCount {
+		t.Errorf("sent %d batches for %d slides at a threshold of one request per batch, want %d",
+			fake.batches, slideCount, slideCount)
+	}
+}
+
+// TestFailedBatchReportsNoCreatedSlides covers the flip side of atomic
+// batches. Nothing a failed batch did survives, so reporting its slides as
+// created would send the rollback chasing IDs that never existed while the
+// caller believes work was done.
+func TestFailedBatchReportsNoCreatedSlides(t *testing.T) {
+	mc, fake := newFakeConverter(t, 0)
+	fake.failCreateAfter = 2 // the batch dies on the third slide
+
+	created, err := mc.appendSlidesFromMarkdown(buildMarkdownDeck(3))
+	if err == nil {
+		t.Fatal("expected an error when the batch fails")
+	}
+
+	if len(created) != 0 {
+		t.Errorf("reported %d created slides from a batch that failed, want 0", len(created))
+	}
+	if len(fake.slides) != 0 {
+		t.Errorf("the deck has %d slides after a failed batch, want 0; "+
+			"a batch is applied atomically", len(fake.slides))
+	}
+}
+
+// TestGeneratedObjectIdsAreValid pins the IDs to what the API accepts. A
+// rejected ID fails the whole batch, and with everything in one batch that
+// means the whole deck.
+func TestGeneratedObjectIdsAreValid(t *testing.T) {
+	// [a-zA-Z0-9_][a-zA-Z0-9_-:]{4,49}, as documented for object IDs
+	valid := regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_:-]{4,49}$`)
+
+	markdown := strings.Join([]string{
+		"# Deck title\n\n## A subtitle\n",
+		"# Heading\n\n- one\n- two\n",
+		"# Numbers\n\n| A | B |\n| --- | --- |\n| 1 | 2 |\n",
+		"# Picture\n\n![a caption](https://example.com/image.png)\n",
+		"# Example\n\nSome prose\n\n```\nfmt.Println()\n```\n",
+	}, "\n---\n\n")
+
+	mc, fake := newFakeConverter(t, 0)
+
+	if _, err := mc.appendSlidesFromMarkdown(markdown); err != nil {
+		t.Fatalf("appendSlidesFromMarkdown() error = %v", err)
+	}
+
+	if len(fake.objectIds) == 0 {
+		t.Fatal("no caller-assigned object IDs were seen; the test is not checking anything")
+	}
+
+	seen := map[string]bool{}
+	for _, id := range fake.objectIds {
+		if !valid.MatchString(id) {
+			t.Errorf("object ID %q is not accepted by the API", id)
+		}
+		if seen[id] {
+			t.Errorf("object ID %q was assigned twice; the batch would be rejected", id)
+		}
+		seen[id] = true
+	}
+}

--- a/slides/batch_test.go
+++ b/slides/batch_test.go
@@ -220,9 +220,7 @@ func TestLayoutPathsProduceTheExpectedContent(t *testing.T) {
 func TestBuildChunksLargeDecks(t *testing.T) {
 	const slideCount = 10
 
-	// Each slide costs more than one request, so a threshold of 1 flushes at
-	// every slide boundary
-	withMaxRequestsPerBatch(t, 1)
+	withMaxRequestsPerBatch(t, 4)
 
 	mc, fake := newFakeConverter(t, 0)
 
@@ -234,9 +232,69 @@ func TestBuildChunksLargeDecks(t *testing.T) {
 	if len(created) != slideCount {
 		t.Fatalf("built %d slides, want %d", len(created), slideCount)
 	}
-	if fake.batches != slideCount {
-		t.Errorf("sent %d batches for %d slides at a threshold of one request per batch, want %d",
-			fake.batches, slideCount, slideCount)
+	if fake.batches < 2 {
+		t.Errorf("sent %d batches for %d slides at a threshold of 4, want the deck split across several",
+			fake.batches, slideCount)
+	}
+	assertBatchesWithinCap(t, fake, 4)
+}
+
+// TestNoBatchExceedsTheCap is the invariant chunking exists for. Checking the
+// buffer only after a whole slide has been appended does not enforce it: a
+// slide landing on an almost-full buffer, or a single slide carrying a large
+// table, pushes one batch past the limit.
+func TestNoBatchExceedsTheCap(t *testing.T) {
+	bigTable := "# Data\n\n| A | B | C | D |\n| --- | --- | --- | --- |\n"
+	for i := 0; i < 30; i++ {
+		bigTable += fmt.Sprintf("| r%dc1 | r%dc2 | r%dc3 | r%dc4 |\n", i, i, i, i)
+	}
+
+	cases := []struct {
+		name     string
+		cap      int
+		markdown string
+	}{
+		{
+			// Ordinary slides arriving on a buffer that is nearly full
+			name:     "slides straddling the boundary",
+			cap:      5,
+			markdown: buildMarkdownDeck(12),
+		},
+		{
+			// One slide whose own requests exceed the cap several times over
+			name:     "a single slide larger than the cap",
+			cap:      8,
+			markdown: bigTable,
+		},
+		{
+			name:     "a big table among ordinary slides",
+			cap:      16,
+			markdown: buildMarkdownDeck(3) + "\n---\n\n" + bigTable + "\n---\n\n" + buildMarkdownDeck(3),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withMaxRequestsPerBatch(t, tc.cap)
+
+			mc, fake := newFakeConverter(t, 0)
+			if _, err := mc.appendSlidesFromMarkdown(tc.markdown); err != nil {
+				t.Fatalf("appendSlidesFromMarkdown() error = %v", err)
+			}
+
+			assertBatchesWithinCap(t, fake, tc.cap)
+		})
+	}
+}
+
+func assertBatchesWithinCap(t *testing.T, fake *fakeSlidesAPI, cap int) {
+	t.Helper()
+
+	for i, size := range fake.batchSizes {
+		if size > cap {
+			t.Errorf("batch %d carried %d requests, exceeding the cap of %d; "+
+				"the API rejects oversized batches", i+1, size, cap)
+		}
 	}
 }
 

--- a/slides/client.go
+++ b/slides/client.go
@@ -111,6 +111,12 @@ func (c *Client) GetLayoutId(presentationId string, layoutName string) (string, 
 		return "", err
 	}
 
+	return findLayoutId(presentation, layoutName)
+}
+
+// findLayoutId resolves a layout name against an already fetched presentation,
+// so a caller building many slides does not have to refetch per lookup.
+func findLayoutId(presentation *slides.Presentation, layoutName string) (string, error) {
 	// Iterate through layouts to find the one with matching name
 	for _, layout := range presentation.Layouts {
 		if layout.LayoutProperties != nil && layout.LayoutProperties.Name == layoutName {
@@ -150,8 +156,25 @@ func (c *Client) ListPresentations() ([]*slides.Presentation, error) {
 	return nil, fmt.Errorf("use Drive API to list presentations")
 }
 
-func (c *Client) CreateSlide(presentationId string, insertionIndex int) (*slides.BatchUpdatePresentationResponse, error) {
-	createSlideReq := &slides.CreateSlideRequest{}
+// createSlideRequests builds a slide creation request. An empty layoutId leaves
+// the layout unspecified, an empty objectId lets the API assign one, and a
+// negative insertionIndex appends the slide to the end of the deck.
+//
+// placeholderIds names the layout's placeholders at creation time so later
+// requests in the same batch can address them; a mapping for a placeholder the
+// layout does not have is rejected by the API, so callers must derive these
+// from the layout itself.
+func createSlideRequests(layoutId string, insertionIndex int, objectId string, placeholderIds []*slides.LayoutPlaceholderIdMapping) []*slides.Request {
+	createSlideReq := &slides.CreateSlideRequest{
+		ObjectId:              objectId,
+		PlaceholderIdMappings: placeholderIds,
+	}
+
+	if layoutId != "" {
+		createSlideReq.SlideLayoutReference = &slides.LayoutReference{
+			LayoutId: layoutId,
+		}
+	}
 
 	// Only set InsertionIndex if it's >= 0
 	// If not set, the slide will be appended to the end
@@ -159,66 +182,34 @@ func (c *Client) CreateSlide(presentationId string, insertionIndex int) (*slides
 		createSlideReq.InsertionIndex = int64(insertionIndex)
 	}
 
-	requests := []*slides.Request{
+	return []*slides.Request{
 		{
 			CreateSlide: createSlideReq,
 		},
 	}
+}
 
-	req := &slides.BatchUpdatePresentationRequest{
-		Requests: requests,
-	}
-
-	return doWithRetry(func() (*slides.BatchUpdatePresentationResponse, error) {
-		return c.service.Presentations.BatchUpdate(presentationId, req).Do()
-	})
+func (c *Client) CreateSlide(presentationId string, insertionIndex int) (*slides.BatchUpdatePresentationResponse, error) {
+	return c.BatchUpdate(presentationId, createSlideRequests("", insertionIndex, "", nil))
 }
 
 // CreateSlideWithLayout creates a new slide with a specific layout
 func (c *Client) CreateSlideWithLayout(presentationId string, layoutId string, insertionIndex int) (*slides.BatchUpdatePresentationResponse, error) {
-	createSlideReq := &slides.CreateSlideRequest{
-		SlideLayoutReference: &slides.LayoutReference{
-			LayoutId: layoutId,
-		},
-	}
-
-	// Only set InsertionIndex if it's >= 0
-	// If not set, the slide will be appended to the end
-	if insertionIndex >= 0 {
-		createSlideReq.InsertionIndex = int64(insertionIndex)
-	}
-
-	requests := []*slides.Request{
-		{
-			CreateSlide: createSlideReq,
-		},
-	}
-
-	req := &slides.BatchUpdatePresentationRequest{
-		Requests: requests,
-	}
-
-	return doWithRetry(func() (*slides.BatchUpdatePresentationResponse, error) {
-		return c.service.Presentations.BatchUpdate(presentationId, req).Do()
-	})
+	return c.BatchUpdate(presentationId, createSlideRequests(layoutId, insertionIndex, "", nil))
 }
 
-func (c *Client) DeleteSlide(presentationId string, slideId string) (*slides.BatchUpdatePresentationResponse, error) {
-	requests := []*slides.Request{
+func deleteSlideRequests(slideId string) []*slides.Request {
+	return []*slides.Request{
 		{
 			DeleteObject: &slides.DeleteObjectRequest{
 				ObjectId: slideId,
 			},
 		},
 	}
+}
 
-	req := &slides.BatchUpdatePresentationRequest{
-		Requests: requests,
-	}
-
-	return doWithRetry(func() (*slides.BatchUpdatePresentationResponse, error) {
-		return c.service.Presentations.BatchUpdate(presentationId, req).Do()
-	})
+func (c *Client) DeleteSlide(presentationId string, slideId string) (*slides.BatchUpdatePresentationResponse, error) {
+	return c.BatchUpdate(presentationId, deleteSlideRequests(slideId))
 }
 
 func (c *Client) DuplicateSlide(presentationId string, slideId string) (*slides.BatchUpdatePresentationResponse, error) {
@@ -242,6 +233,10 @@ func (c *Client) DuplicateSlide(presentationId string, slideId string) (*slides.
 // ReplaceAllTextInShape replaces all text in existing shapes on a slide
 // processMarkdownText processes markdown formatting and returns clean text with format ranges
 func (c *Client) processMarkdownText(text string) (string, []FormatRange) {
+	return processMarkdownText(text)
+}
+
+func processMarkdownText(text string) (string, []FormatRange) {
 	// Temporarily disable all formatting to avoid character counting issues
 	// Just remove markdown markers without applying any formatting
 	result := text
@@ -289,10 +284,11 @@ func (c *Client) ReplaceAllTextInSlide(presentationId string, slideId string, ol
 	})
 }
 
-// InsertTextInPlaceholder inserts text into a placeholder shape
-func (c *Client) InsertTextInPlaceholder(presentationId string, shapeId string, text string) (*slides.BatchUpdatePresentationResponse, error) {
+// insertTextInPlaceholderRequests builds the requests that fill a placeholder
+// shape with markdown-formatted text.
+func insertTextInPlaceholderRequests(shapeId string, text string) []*slides.Request {
 	// Process markdown formatting properly for placeholders
-	processedText, formatRanges := c.processMarkdownTextWithFormatting(text)
+	processedText, formatRanges := processMarkdownTextWithFormatting(text)
 
 	requests := []*slides.Request{
 		{
@@ -325,17 +321,20 @@ func (c *Client) InsertTextInPlaceholder(presentationId string, shapeId string, 
 	// Don't apply Courier New font to all text anymore
 	// Code blocks and inline code are handled in processMarkdownTextWithFormatting
 
-	req := &slides.BatchUpdatePresentationRequest{
-		Requests: requests,
-	}
+	return requests
+}
 
-	return doWithRetry(func() (*slides.BatchUpdatePresentationResponse, error) {
-		return c.service.Presentations.BatchUpdate(presentationId, req).Do()
-	})
+// InsertTextInPlaceholder inserts text into a placeholder shape
+func (c *Client) InsertTextInPlaceholder(presentationId string, shapeId string, text string) (*slides.BatchUpdatePresentationResponse, error) {
+	return c.BatchUpdate(presentationId, insertTextInPlaceholderRequests(shapeId, text))
 }
 
 // processMarkdownTextWithFormatting processes markdown with proper formatting for placeholders
 func (c *Client) processMarkdownTextWithFormatting(text string) (string, []FormatRange) {
+	return processMarkdownTextWithFormatting(text)
+}
+
+func processMarkdownTextWithFormatting(text string) (string, []FormatRange) {
 	var formatRanges []FormatRange
 	result := text
 
@@ -554,9 +553,8 @@ func (c *Client) processMarkdownTextWithFormatting(text string) (string, []Forma
 	return result, formatRanges
 }
 
-// DeleteTextInPlaceholder deletes existing text in a placeholder
-func (c *Client) DeleteTextInPlaceholder(presentationId string, shapeId string) (*slides.BatchUpdatePresentationResponse, error) {
-	requests := []*slides.Request{
+func deleteTextInPlaceholderRequests(shapeId string) []*slides.Request {
+	return []*slides.Request{
 		{
 			DeleteText: &slides.DeleteTextRequest{
 				ObjectId: shapeId,
@@ -566,17 +564,16 @@ func (c *Client) DeleteTextInPlaceholder(presentationId string, shapeId string) 
 			},
 		},
 	}
-
-	req := &slides.BatchUpdatePresentationRequest{
-		Requests: requests,
-	}
-
-	return doWithRetry(func() (*slides.BatchUpdatePresentationResponse, error) {
-		return c.service.Presentations.BatchUpdate(presentationId, req).Do()
-	})
 }
 
-func (c *Client) AddTextBox(presentationId string, slideId string, text string, x, y, width, height float64) (*slides.BatchUpdatePresentationResponse, error) {
+// DeleteTextInPlaceholder deletes existing text in a placeholder
+func (c *Client) DeleteTextInPlaceholder(presentationId string, shapeId string) (*slides.BatchUpdatePresentationResponse, error) {
+	return c.BatchUpdate(presentationId, deleteTextInPlaceholderRequests(shapeId))
+}
+
+// addTextBoxRequests builds the requests that place a text box on a slide under
+// a caller-supplied element ID.
+func addTextBoxRequests(slideId string, elementId string, text string, x, y, width, height float64) []*slides.Request {
 	// Validate dimensions to avoid "affine transform is not invertible" error
 	if width <= 0 {
 		width = 400 // Default width
@@ -585,10 +582,8 @@ func (c *Client) AddTextBox(presentationId string, slideId string, text string, 
 		height = 100 // Default height
 	}
 
-	elementId := fmt.Sprintf("textbox_%s", generateId())
-
 	// Process markdown formatting (bold and italic)
-	processedText, formatRanges := c.processMarkdownText(text)
+	processedText, formatRanges := processMarkdownText(text)
 
 	requests := []*slides.Request{
 		{
@@ -629,6 +624,13 @@ func (c *Client) AddTextBox(presentationId string, slideId string, text string, 
 	// Skip text styling for now to avoid character counting issues
 	_ = formatRanges
 
+	return requests
+}
+
+func (c *Client) AddTextBox(presentationId string, slideId string, text string, x, y, width, height float64) (*slides.BatchUpdatePresentationResponse, error) {
+	elementId := fmt.Sprintf("textbox_%s", generateId())
+	requests := addTextBoxRequests(slideId, elementId, text, x, y, width, height)
+
 	req := &slides.BatchUpdatePresentationRequest{
 		Requests: requests,
 	}
@@ -646,7 +648,8 @@ func (c *Client) AddTextBox(presentationId string, slideId string, text string, 
 	return resp, nil
 }
 
-func (c *Client) AddCodeTextBox(presentationId string, slideId string, text string, x, y, width, height float64) (*slides.BatchUpdatePresentationResponse, error) {
+// addCodeTextBoxRequests builds the requests for a monospaced text box.
+func addCodeTextBoxRequests(slideId string, elementId string, text string, x, y, width, height float64) []*slides.Request {
 	// Validate dimensions
 	if width <= 0 {
 		width = 400
@@ -655,12 +658,10 @@ func (c *Client) AddCodeTextBox(presentationId string, slideId string, text stri
 		height = 100
 	}
 
-	elementId := fmt.Sprintf("codebox_%s", generateId())
-
 	// Remove markdown markers but don't apply formatting
-	processedText, _ := c.processMarkdownText(text)
+	processedText, _ := processMarkdownText(text)
 
-	requests := []*slides.Request{
+	return []*slides.Request{
 		{
 			CreateShape: &slides.CreateShapeRequest{
 				ObjectId:  elementId,
@@ -707,20 +708,16 @@ func (c *Client) AddCodeTextBox(presentationId string, slideId string, text stri
 			},
 		},
 	}
-
-	req := &slides.BatchUpdatePresentationRequest{
-		Requests: requests,
-	}
-
-	return doWithRetry(func() (*slides.BatchUpdatePresentationResponse, error) {
-		return c.service.Presentations.BatchUpdate(presentationId, req).Do()
-	})
 }
 
-func (c *Client) AddImage(presentationId string, slideId string, imageUrl string, x, y, width, height float64) (*slides.BatchUpdatePresentationResponse, error) {
-	elementId := fmt.Sprintf("image_%s", generateId())
+func (c *Client) AddCodeTextBox(presentationId string, slideId string, text string, x, y, width, height float64) (*slides.BatchUpdatePresentationResponse, error) {
+	elementId := fmt.Sprintf("codebox_%s", generateId())
+	return c.BatchUpdate(presentationId, addCodeTextBoxRequests(slideId, elementId, text, x, y, width, height))
+}
 
-	requests := []*slides.Request{
+// addImageRequests builds the request that places an image on a slide.
+func addImageRequests(slideId string, elementId string, imageUrl string, x, y, width, height float64) []*slides.Request {
+	return []*slides.Request{
 		{
 			CreateImage: &slides.CreateImageRequest{
 				ObjectId: elementId,
@@ -748,17 +745,16 @@ func (c *Client) AddImage(presentationId string, slideId string, imageUrl string
 			},
 		},
 	}
-
-	req := &slides.BatchUpdatePresentationRequest{
-		Requests: requests,
-	}
-
-	return doWithRetry(func() (*slides.BatchUpdatePresentationResponse, error) {
-		return c.service.Presentations.BatchUpdate(presentationId, req).Do()
-	})
 }
 
-func (c *Client) AddTable(presentationId string, slideId string, rows, columns int, x, y, width, height float64) (*slides.BatchUpdatePresentationResponse, error) {
+func (c *Client) AddImage(presentationId string, slideId string, imageUrl string, x, y, width, height float64) (*slides.BatchUpdatePresentationResponse, error) {
+	elementId := fmt.Sprintf("image_%s", generateId())
+	return c.BatchUpdate(presentationId, addImageRequests(slideId, elementId, imageUrl, x, y, width, height))
+}
+
+// addTableRequests builds the request that places a table on a slide. The
+// caller-supplied element ID lets cells be filled in the same batch.
+func addTableRequests(slideId string, elementId string, rows, columns int, x, y, width, height float64) []*slides.Request {
 	// Validate dimensions to avoid "affine transform is not invertible" error
 	if width <= 0 {
 		width = 400 // Default width
@@ -773,9 +769,7 @@ func (c *Client) AddTable(presentationId string, slideId string, rows, columns i
 		columns = 1
 	}
 
-	elementId := fmt.Sprintf("table_%s", generateId())
-
-	requests := []*slides.Request{
+	return []*slides.Request{
 		{
 			CreateTable: &slides.CreateTableRequest{
 				ObjectId: elementId,
@@ -804,17 +798,15 @@ func (c *Client) AddTable(presentationId string, slideId string, rows, columns i
 			},
 		},
 	}
-
-	req := &slides.BatchUpdatePresentationRequest{
-		Requests: requests,
-	}
-
-	return doWithRetry(func() (*slides.BatchUpdatePresentationResponse, error) {
-		return c.service.Presentations.BatchUpdate(presentationId, req).Do()
-	})
 }
 
-func (c *Client) AddShape(presentationId string, slideId string, shapeType string, x, y, width, height float64) (*slides.BatchUpdatePresentationResponse, error) {
+func (c *Client) AddTable(presentationId string, slideId string, rows, columns int, x, y, width, height float64) (*slides.BatchUpdatePresentationResponse, error) {
+	elementId := fmt.Sprintf("table_%s", generateId())
+	return c.BatchUpdate(presentationId, addTableRequests(slideId, elementId, rows, columns, x, y, width, height))
+}
+
+// addShapeRequests builds the request that places a shape on a slide.
+func addShapeRequests(slideId string, elementId string, shapeType string, x, y, width, height float64) []*slides.Request {
 	// Validate dimensions to avoid "affine transform is not invertible" error
 	if width <= 0 {
 		width = 100 // Default width
@@ -823,9 +815,7 @@ func (c *Client) AddShape(presentationId string, slideId string, shapeType strin
 		height = 100 // Default height
 	}
 
-	elementId := fmt.Sprintf("shape_%s", generateId())
-
-	requests := []*slides.Request{
+	return []*slides.Request{
 		{
 			CreateShape: &slides.CreateShapeRequest{
 				ObjectId:  elementId,
@@ -853,14 +843,11 @@ func (c *Client) AddShape(presentationId string, slideId string, shapeType strin
 			},
 		},
 	}
+}
 
-	req := &slides.BatchUpdatePresentationRequest{
-		Requests: requests,
-	}
-
-	return doWithRetry(func() (*slides.BatchUpdatePresentationResponse, error) {
-		return c.service.Presentations.BatchUpdate(presentationId, req).Do()
-	})
+func (c *Client) AddShape(presentationId string, slideId string, shapeType string, x, y, width, height float64) (*slides.BatchUpdatePresentationResponse, error) {
+	elementId := fmt.Sprintf("shape_%s", generateId())
+	return c.BatchUpdate(presentationId, addShapeRequests(slideId, elementId, shapeType, x, y, width, height))
 }
 
 func (c *Client) ApplyTemplate(presentationId string, templateId string) (*slides.BatchUpdatePresentationResponse, error) {
@@ -901,9 +888,8 @@ func (c *Client) BatchUpdate(presentationId string, requests []*slides.Request) 
 	})
 }
 
-// InsertTextInTableCell inserts text into a specific table cell
-func (c *Client) InsertTextInTableCell(presentationId string, tableId string, row, col int, text string) (*slides.BatchUpdatePresentationResponse, error) {
-	requests := []*slides.Request{
+func insertTextInTableCellRequests(tableId string, row, col int, text string) []*slides.Request {
+	return []*slides.Request{
 		{
 			InsertText: &slides.InsertTextRequest{
 				ObjectId: tableId,
@@ -916,21 +902,21 @@ func (c *Client) InsertTextInTableCell(presentationId string, tableId string, ro
 			},
 		},
 	}
-
-	req := &slides.BatchUpdatePresentationRequest{
-		Requests: requests,
-	}
-
-	return doWithRetry(func() (*slides.BatchUpdatePresentationResponse, error) {
-		return c.service.Presentations.BatchUpdate(presentationId, req).Do()
-	})
 }
 
-// ApplyCodeFormattingToPlaceholder applies Courier New font to specific text ranges in a placeholder
-func (c *Client) ApplyCodeFormattingToPlaceholder(presentationId string, shapeId string, codeRanges []struct {
+// InsertTextInTableCell inserts text into a specific table cell
+func (c *Client) InsertTextInTableCell(presentationId string, tableId string, row, col int, text string) (*slides.BatchUpdatePresentationResponse, error) {
+	return c.BatchUpdate(presentationId, insertTextInTableCellRequests(tableId, row, col, text))
+}
+
+// codeRange is a half-open UTF-16 range within a shape's text that should be
+// rendered monospaced.
+type codeRange struct {
 	start int
 	end   int
-}) error {
+}
+
+func applyCodeFormattingRequests(shapeId string, codeRanges []codeRange) []*slides.Request {
 	var requests []*slides.Request
 
 	for _, cr := range codeRanges {
@@ -952,6 +938,20 @@ func (c *Client) ApplyCodeFormattingToPlaceholder(presentationId string, shapeId
 		})
 	}
 
+	return requests
+}
+
+// ApplyCodeFormattingToPlaceholder applies Courier New font to specific text ranges in a placeholder
+func (c *Client) ApplyCodeFormattingToPlaceholder(presentationId string, shapeId string, codeRanges []struct {
+	start int
+	end   int
+}) error {
+	converted := make([]codeRange, 0, len(codeRanges))
+	for _, cr := range codeRanges {
+		converted = append(converted, codeRange{start: cr.start, end: cr.end})
+	}
+
+	requests := applyCodeFormattingRequests(shapeId, converted)
 	if len(requests) == 0 {
 		return nil
 	}

--- a/slides/markdown.go
+++ b/slides/markdown.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"regexp"
 	"strings"
+	"time"
 	"unicode/utf16"
 
 	"google.golang.org/api/slides/v1"
@@ -342,6 +343,161 @@ func (mc *MarkdownConverter) CreateSlidesFromMarkdown(markdown string) ([]*slide
 	return updatedPresentation.Slides, nil
 }
 
+// maxRequestsPerBatch caps how many requests one batchUpdate carries. A batch
+// is applied atomically, so a whole deck in a single call is the cheapest and
+// safest shape; the cap only exists because a very large deck could exceed the
+// API's per-request limits. It is a variable so tests can force chunking
+// without building an enormous deck.
+var maxRequestsPerBatch = 500
+
+// slideBatch accumulates requests and sends them in as few batchUpdate calls as
+// possible. Object IDs are assigned here rather than read back from the API,
+// which is what lets a slide and everything on it be built in one round trip.
+type slideBatch struct {
+	client         *Client
+	presentationId string
+	prefix         string
+	nextId         int
+
+	pending []*slides.Request
+	// Slides whose requests are still pending. A failed batch is rolled back
+	// by the API, so these must not be reported as created until they flush.
+	pendingSlideIds []string
+	createdSlideIds []string
+}
+
+func newSlideBatch(client *Client, presentationId string) *slideBatch {
+	return &slideBatch{
+		client:         client,
+		presentationId: presentationId,
+		prefix:         newObjectIdPrefix(),
+	}
+}
+
+// newObjectIdPrefix returns a prefix unique to this run, so generated IDs
+// cannot collide with objects already in the presentation.
+func newObjectIdPrefix() string {
+	return fmt.Sprintf("md%d", time.Now().UnixNano())
+}
+
+// id returns a fresh object ID. The API accepts [a-zA-Z0-9_][a-zA-Z0-9_-:]{4,49},
+// which the prefix, kind and counter stay well inside.
+func (b *slideBatch) id(kind string) string {
+	b.nextId++
+	return fmt.Sprintf("%s-%s%d", b.prefix, kind, b.nextId)
+}
+
+func (b *slideBatch) add(requests ...*slides.Request) {
+	b.pending = append(b.pending, requests...)
+}
+
+// addSlide records a slide the pending requests create.
+func (b *slideBatch) addSlide(slideId string) {
+	b.pendingSlideIds = append(b.pendingSlideIds, slideId)
+}
+
+func (b *slideBatch) flush() error {
+	if len(b.pending) == 0 {
+		return nil
+	}
+
+	pending := b.pending
+	b.pending = nil
+	pendingSlideIds := b.pendingSlideIds
+	b.pendingSlideIds = nil
+
+	if _, err := b.client.BatchUpdate(b.presentationId, pending); err != nil {
+		return err
+	}
+
+	b.createdSlideIds = append(b.createdSlideIds, pendingSlideIds...)
+	return nil
+}
+
+// flushIfFull sends the pending requests once they reach the cap. It is called
+// at slide boundaries so a chunk never splits a slide in half.
+func (b *slideBatch) flushIfFull() error {
+	if len(b.pending) < maxRequestsPerBatch {
+		return nil
+	}
+	return b.flush()
+}
+
+// layoutPlaceholders holds a layout's own placeholder element IDs.
+// CreateSlideRequest.PlaceholderIdMappings rejects a mapping for a placeholder
+// the layout does not define, so these are read from the layout itself rather
+// than assumed.
+type layoutPlaceholders struct {
+	title    string
+	body     string
+	subtitle string
+}
+
+func placeholdersForLayout(presentation *slides.Presentation, layoutId string) layoutPlaceholders {
+	var found layoutPlaceholders
+	if layoutId == "" {
+		return found
+	}
+
+	for _, layout := range presentation.Layouts {
+		if layout.ObjectId != layoutId {
+			continue
+		}
+		for _, element := range layout.PageElements {
+			if element.Shape == nil || element.Shape.Placeholder == nil {
+				continue
+			}
+			switch element.Shape.Placeholder.Type {
+			case "TITLE", "CENTERED_TITLE":
+				if found.title == "" {
+					found.title = element.ObjectId
+				}
+			case "BODY":
+				if found.body == "" {
+					found.body = element.ObjectId
+				}
+			case "SUBTITLE":
+				if found.subtitle == "" {
+					found.subtitle = element.ObjectId
+				}
+			}
+		}
+	}
+
+	return found
+}
+
+// slidePlaceholderIds names the placeholders this run will write to, and
+// returns the mappings that bind those names at slide creation time.
+type slidePlaceholderIds struct {
+	title    string
+	body     string
+	subtitle string
+}
+
+func (b *slideBatch) mapPlaceholders(layout layoutPlaceholders) (slidePlaceholderIds, []*slides.LayoutPlaceholderIdMapping) {
+	var ids slidePlaceholderIds
+	var mappings []*slides.LayoutPlaceholderIdMapping
+
+	bind := func(layoutObjectId, kind string) string {
+		if layoutObjectId == "" {
+			return ""
+		}
+		objectId := b.id(kind)
+		mappings = append(mappings, &slides.LayoutPlaceholderIdMapping{
+			LayoutPlaceholderObjectId: layoutObjectId,
+			ObjectId:                  objectId,
+		})
+		return objectId
+	}
+
+	ids.title = bind(layout.title, "title")
+	ids.body = bind(layout.body, "body")
+	ids.subtitle = bind(layout.subtitle, "sub")
+
+	return ids, mappings
+}
+
 // appendSlidesFromMarkdown appends the slides described by markdown to the end
 // of the presentation and returns their IDs. It never deletes anything, so a
 // caller replacing a deck can keep the old slides until the new ones are
@@ -351,10 +507,16 @@ func (mc *MarkdownConverter) CreateSlidesFromMarkdown(markdown string) ([]*slide
 // clean them up rather than leaving them stranded in the presentation.
 func (mc *MarkdownConverter) appendSlidesFromMarkdown(markdown string) ([]string, error) {
 	parsedSlides := mc.ParseMarkdown(markdown)
-	createdSlideIds := make([]string, 0, len(parsedSlides))
+
+	// One fetch for the whole deck. The layouts carry the placeholder IDs every
+	// slide needs, so nothing here has to be read back per slide.
+	presentation, err := mc.client.GetPresentation(mc.presentationId)
+	if err != nil {
+		return nil, err
+	}
 
 	// Get the TITLE_AND_BODY layout ID
-	layoutId, err := mc.client.GetLayoutId(mc.presentationId, "TITLE_AND_BODY")
+	layoutId, err := findLayoutId(presentation, "TITLE_AND_BODY")
 	if err != nil {
 		// Fallback to blank slides if layout not found
 		log.Printf("[WARNING] Failed to get TITLE_AND_BODY layout: %v\n", err)
@@ -362,11 +524,24 @@ func (mc *MarkdownConverter) appendSlidesFromMarkdown(markdown string) ([]string
 	}
 
 	// Get the TITLE layout ID for title slides (slides with only two headings)
-	titleLayoutId, _ := mc.client.GetLayoutId(mc.presentationId, "TITLE")
+	titleLayoutId, _ := findLayoutId(presentation, "TITLE")
 
 	// Create all slides fresh
 	// Get the TITLE_ONLY layout ID for slides with tables
-	titleOnlyLayoutId, _ := mc.client.GetLayoutId(mc.presentationId, "TITLE_ONLY")
+	titleOnlyLayoutId, _ := findLayoutId(presentation, "TITLE_ONLY")
+
+	bodyLayout := placeholdersForLayout(presentation, layoutId)
+	titleLayout := placeholdersForLayout(presentation, titleLayoutId)
+	titleOnlyLayout := placeholdersForLayout(presentation, titleOnlyLayoutId)
+
+	// The TITLE layout's subtitle slot is a SUBTITLE placeholder in most themes
+	// and a BODY one in the rest.
+	if titleLayout.subtitle == "" {
+		titleLayout.subtitle = titleLayout.body
+		titleLayout.body = ""
+	}
+
+	batch := newSlideBatch(mc.client, mc.presentationId)
 
 	for i, slide := range parsedSlides {
 		// Check if slide contains tables or images (both need more space)
@@ -404,129 +579,82 @@ func (mc *MarkdownConverter) appendSlidesFromMarkdown(markdown string) ([]string
 			isTitleSlide = (headingCount == 2 && nonHeadingCount == 0) || (i == 0 && headingCount > 0 && nonHeadingCount == 0)
 		}
 
-		// Choose layout based on content
-		var resp *slides.BatchUpdatePresentationResponse
-		var useLayoutBased bool
-		var layoutType string
+		// Choose layout based on content, naming the placeholders up front so the
+		// same batch can fill them.
+		slideId := batch.id("s")
+		var placeholders slidePlaceholderIds
+		var mappings []*slides.LayoutPlaceholderIdMapping
+		var createLayoutId, layoutType string
 		if isTitleSlide && titleLayoutId != "" {
 			// Use TITLE layout for title slides
-			resp, err = mc.client.CreateSlideWithLayout(mc.presentationId, titleLayoutId, -1)
-			useLayoutBased = true
+			createLayoutId = titleLayoutId
+			placeholders, mappings = batch.mapPlaceholders(titleLayout)
 			layoutType = "TITLE"
 		} else if needsTitleOnlyLayout && titleOnlyLayoutId != "" {
 			// Use TITLE_ONLY layout for slides with tables or images
-			resp, err = mc.client.CreateSlideWithLayout(mc.presentationId, titleOnlyLayoutId, -1)
-			useLayoutBased = true
+			createLayoutId = titleOnlyLayoutId
+			placeholders, mappings = batch.mapPlaceholders(titleOnlyLayout)
 			layoutType = "TITLE_ONLY"
 		} else if layoutId != "" {
 			// Use TITLE_AND_BODY layout for regular slides
-			resp, err = mc.client.CreateSlideWithLayout(mc.presentationId, layoutId, -1)
-			useLayoutBased = true
+			createLayoutId = layoutId
+			placeholders, mappings = batch.mapPlaceholders(bodyLayout)
 			layoutType = "TITLE_AND_BODY"
 		} else {
 			// Fallback to blank slide
-			resp, err = mc.client.CreateSlide(mc.presentationId, -1)
-			useLayoutBased = false
 			layoutType = "BLANK"
 		}
 
-		if err != nil {
-			return createdSlideIds, fmt.Errorf("failed to create slide %d: %w", i+1, err)
-		}
-
-		var slideId string
-		if len(resp.Replies) > 0 && resp.Replies[0].CreateSlide != nil {
-			slideId = resp.Replies[0].CreateSlide.ObjectId
-		} else {
-			return createdSlideIds, fmt.Errorf("failed to get slide ID for slide %d", i+1)
-		}
-		createdSlideIds = append(createdSlideIds, slideId)
+		batch.add(createSlideRequests(createLayoutId, -1, slideId, mappings)...)
+		batch.addSlide(slideId)
 
 		// Populate slide based on layout type and content
-		if useLayoutBased {
-			if layoutType == "TITLE" {
-				// Special handling for title slides
-				err = mc.populateSlideWithTitleLayout(slideId, slide)
-			} else if layoutType == "TITLE_ONLY" {
-				// Special handling for slides with tables (TITLE_ONLY layout)
-				err = mc.populateSlideWithTableLayout(slideId, slide)
-			} else {
-				// Regular TITLE_AND_BODY layout
-				err = mc.populateSlideWithLayout(slideId, slide)
-			}
-		} else {
+		switch layoutType {
+		case "TITLE":
+			// Special handling for title slides
+			populateSlideWithTitleLayout(batch, placeholders, slide)
+		case "TITLE_ONLY":
+			// Special handling for slides with tables (TITLE_ONLY layout)
+			populateSlideWithTableLayout(batch, slideId, placeholders, slide)
+		case "TITLE_AND_BODY":
+			// Regular TITLE_AND_BODY layout
+			populateSlideWithLayout(batch, placeholders, slide)
+		default:
 			// Blank slide
-			err = mc.populateSlide(slideId, slide)
+			populateSlide(batch, slideId, slide)
 		}
 
-		if err != nil {
-			return createdSlideIds, fmt.Errorf("failed to populate slide %d: %w", i+1, err)
+		if err := batch.flushIfFull(); err != nil {
+			return batch.createdSlideIds, fmt.Errorf("failed to create slide %d: %w", i+1, err)
 		}
 	}
 
-	return createdSlideIds, nil
+	if err := batch.flush(); err != nil {
+		return batch.createdSlideIds, fmt.Errorf("failed to create %d slides: %w", len(parsedSlides), err)
+	}
+
+	return batch.createdSlideIds, nil
 }
 
-// populateSlideWithLayout populates a slide that uses a predefined layout
-func (mc *MarkdownConverter) populateSlideWithLayout(slideId string, slide MarkdownSlide) error {
-	// Get the slide to find placeholder shapes
-	presentation, err := mc.client.GetPresentation(mc.presentationId)
-	if err != nil {
-		return fmt.Errorf("failed to get presentation: %w", err)
-	}
-
-	// Find the slide we just created
-	var currentSlide *slides.Page
-	for _, s := range presentation.Slides {
-		if s.ObjectId == slideId {
-			currentSlide = s
-			break
-		}
-	}
-
-	if currentSlide == nil {
-		return fmt.Errorf("slide not found: %s", slideId)
-	}
-
-	// Find title and body placeholders
-	var titlePlaceholderId, bodyPlaceholderId string
-	for _, element := range currentSlide.PageElements {
-		if element.Shape != nil && element.Shape.Placeholder != nil {
-			switch element.Shape.Placeholder.Type {
-			case "TITLE", "CENTERED_TITLE":
-				titlePlaceholderId = element.ObjectId
-			case "BODY":
-				bodyPlaceholderId = element.ObjectId
-			}
-		}
-	}
+// populateSlideWithLayout populates a slide that uses a predefined layout.
+//
+// The placeholders belong to a slide created in this same batch, so they are
+// still empty; the delete-text calls the unbatched path made first would fail
+// the whole batch rather than being ignorable.
+func populateSlideWithLayout(b *slideBatch, placeholders slidePlaceholderIds, slide MarkdownSlide) {
+	titlePlaceholderId, bodyPlaceholderId := placeholders.title, placeholders.body
 
 	// Insert title if we have a title placeholder
 	if titlePlaceholderId != "" && slide.Title != "" {
-		// Delete existing placeholder text
-		// Ignore error as placeholder might be empty
-		_, _ = mc.client.DeleteTextInPlaceholder(mc.presentationId, titlePlaceholderId)
-
-		// Insert new title text
-		_, err = mc.client.InsertTextInPlaceholder(mc.presentationId, titlePlaceholderId, slide.Title)
-		if err != nil {
-			return fmt.Errorf("failed to insert title: %w", err)
-		}
+		b.add(insertTextInPlaceholderRequests(titlePlaceholderId, slide.Title)...)
 	}
 
 	// Insert body content if we have a body placeholder
 	if bodyPlaceholderId != "" && len(slide.Content) > 0 {
-		// Delete existing placeholder text
-		// Ignore error as placeholder might be empty
-		_, _ = mc.client.DeleteTextInPlaceholder(mc.presentationId, bodyPlaceholderId)
-
 		// Find the first heading (Level 2 or 3) to use as title if slide.Title is empty
 		var slideTitle string
 		var bodyText []string
-		var codeRanges []struct {
-			start int
-			end   int
-		}
+		var codeRanges []codeRange
 
 		// Build the text and track code positions using UTF-16 code units
 		currentPos := 0
@@ -570,10 +698,7 @@ func (mc *MarkdownConverter) populateSlideWithLayout(slideId string, slide Markd
 				// Track the position of code blocks for formatting using UTF-16 code units
 				codeStart := currentPos
 				codeEnd := currentPos + len(utf16.Encode([]rune(element.Content)))
-				codeRanges = append(codeRanges, struct {
-					start int
-					end   int
-				}{
+				codeRanges = append(codeRanges, codeRange{
 					start: codeStart,
 					end:   codeEnd,
 				})
@@ -587,71 +712,24 @@ func (mc *MarkdownConverter) populateSlideWithLayout(slideId string, slide Markd
 
 		// If we found a heading and no slide title was set, use it as title
 		if slideTitle != "" && slide.Title == "" && titlePlaceholderId != "" {
-			// Ignore error as placeholder might be empty
-			_, _ = mc.client.DeleteTextInPlaceholder(mc.presentationId, titlePlaceholderId)
-
-			_, err = mc.client.InsertTextInPlaceholder(mc.presentationId, titlePlaceholderId, slideTitle)
-			if err != nil {
-				return fmt.Errorf("failed to insert title: %w", err)
-			}
+			b.add(insertTextInPlaceholderRequests(titlePlaceholderId, slideTitle)...)
 		}
 
 		if len(bodyText) > 0 {
 			combinedText := strings.Join(bodyText, "\n")
-			_, err = mc.client.InsertTextInPlaceholder(mc.presentationId, bodyPlaceholderId, combinedText)
-			if err != nil {
-				return fmt.Errorf("failed to insert body text: %w", err)
-			}
+			b.add(insertTextInPlaceholderRequests(bodyPlaceholderId, combinedText)...)
 
 			// Apply Courier New font to code blocks
-			if len(codeRanges) > 0 {
-				err = mc.client.ApplyCodeFormattingToPlaceholder(mc.presentationId, bodyPlaceholderId, codeRanges)
-				if err != nil {
-					// Return the error so we can see what's happening
-					return fmt.Errorf("failed to apply code formatting: %w", err)
-				}
-			}
+			b.add(applyCodeFormattingRequests(bodyPlaceholderId, codeRanges)...)
 		}
 	}
-
-	return nil
 }
 
 // populateSlideWithTitleLayout populates a slide with TITLE layout (for title slides with only headings)
 // This function is used for slides that contain only headings (typically 2: title and subtitle)
 // It maps the headings to the appropriate title and subtitle placeholders in the TITLE layout
-func (mc *MarkdownConverter) populateSlideWithTitleLayout(slideId string, slide MarkdownSlide) error {
-	// Get the slide to find placeholder shapes
-	presentation, err := mc.client.GetPresentation(mc.presentationId)
-	if err != nil {
-		return fmt.Errorf("failed to get presentation: %w", err)
-	}
-
-	// Find the slide we just created
-	var currentSlide *slides.Page
-	for _, s := range presentation.Slides {
-		if s.ObjectId == slideId {
-			currentSlide = s
-			break
-		}
-	}
-
-	if currentSlide == nil {
-		return fmt.Errorf("slide not found: %s", slideId)
-	}
-
-	// Find title and subtitle placeholders
-	var titlePlaceholderId, subtitlePlaceholderId string
-	for _, element := range currentSlide.PageElements {
-		if element.Shape != nil && element.Shape.Placeholder != nil {
-			switch element.Shape.Placeholder.Type {
-			case "TITLE", "CENTERED_TITLE":
-				titlePlaceholderId = element.ObjectId
-			case "SUBTITLE", "BODY":
-				subtitlePlaceholderId = element.ObjectId
-			}
-		}
-	}
+func populateSlideWithTitleLayout(b *slideBatch, placeholders slidePlaceholderIds, slide MarkdownSlide) {
+	titlePlaceholderId, subtitlePlaceholderId := placeholders.title, placeholders.subtitle
 
 	// Extract headings from content
 	var headings []string
@@ -682,61 +760,19 @@ func (mc *MarkdownConverter) populateSlideWithTitleLayout(slideId string, slide 
 
 	// Insert title
 	if titlePlaceholderId != "" && titleText != "" {
-		// Ignore error as placeholder might be empty
-		_, _ = mc.client.DeleteTextInPlaceholder(mc.presentationId, titlePlaceholderId)
-
-		_, err = mc.client.InsertTextInPlaceholder(mc.presentationId, titlePlaceholderId, titleText)
-		if err != nil {
-			return fmt.Errorf("failed to insert title: %w", err)
-		}
+		b.add(insertTextInPlaceholderRequests(titlePlaceholderId, titleText)...)
 	}
 
 	// Insert subtitle
 	if subtitlePlaceholderId != "" && subtitleText != "" {
-		// Ignore error as placeholder might be empty
-		_, _ = mc.client.DeleteTextInPlaceholder(mc.presentationId, subtitlePlaceholderId)
-
-		_, err = mc.client.InsertTextInPlaceholder(mc.presentationId, subtitlePlaceholderId, subtitleText)
-		if err != nil {
-			return fmt.Errorf("failed to insert subtitle: %w", err)
-		}
+		b.add(insertTextInPlaceholderRequests(subtitlePlaceholderId, subtitleText)...)
 	}
-
-	return nil
 }
 
 // populateSlideWithTableLayout populates a slide with TITLE_ONLY layout that contains tables or images
 // This layout provides more space for content that needs it (tables, images)
-func (mc *MarkdownConverter) populateSlideWithTableLayout(slideId string, slide MarkdownSlide) error {
-	// Get the slide to find placeholder shapes
-	presentation, err := mc.client.GetPresentation(mc.presentationId)
-	if err != nil {
-		return fmt.Errorf("failed to get presentation: %w", err)
-	}
-
-	// Find the slide we just created
-	var currentSlide *slides.Page
-	for _, s := range presentation.Slides {
-		if s.ObjectId == slideId {
-			currentSlide = s
-			break
-		}
-	}
-
-	if currentSlide == nil {
-		return fmt.Errorf("slide not found: %s", slideId)
-	}
-
-	// Find title placeholder
-	var titlePlaceholderId string
-	for _, element := range currentSlide.PageElements {
-		if element.Shape != nil && element.Shape.Placeholder != nil {
-			switch element.Shape.Placeholder.Type {
-			case "TITLE", "CENTERED_TITLE":
-				titlePlaceholderId = element.ObjectId
-			}
-		}
-	}
+func populateSlideWithTableLayout(b *slideBatch, slideId string, placeholders slidePlaceholderIds, slide MarkdownSlide) {
+	titlePlaceholderId := placeholders.title
 
 	// Insert title - use slide title or first heading from content
 	titleText := slide.Title
@@ -751,15 +787,7 @@ func (mc *MarkdownConverter) populateSlideWithTableLayout(slideId string, slide 
 	}
 
 	if titlePlaceholderId != "" && titleText != "" {
-		// Delete existing placeholder text
-		// Ignore error as placeholder might be empty
-		_, _ = mc.client.DeleteTextInPlaceholder(mc.presentationId, titlePlaceholderId)
-
-		// Insert title text
-		_, err = mc.client.InsertTextInPlaceholder(mc.presentationId, titlePlaceholderId, titleText)
-		if err != nil {
-			return fmt.Errorf("failed to insert title: %w", err)
-		}
+		b.add(insertTextInPlaceholderRequests(titlePlaceholderId, titleText)...)
 	}
 
 	// Add content manually below the title
@@ -778,18 +806,15 @@ func (mc *MarkdownConverter) populateSlideWithTableLayout(slideId string, slide 
 				fontSize = H1FontSize
 			}
 
-			_, err := mc.client.AddTextBox(
-				mc.presentationId,
+			b.add(addTextBoxRequests(
 				slideId,
+				b.id("tb"),
 				element.Content,
 				MarginLeft,
 				currentY,
 				SlideWidth-MarginLeft-MarginRight,
 				fontSize*LineHeight,
-			)
-			if err != nil {
-				return err
-			}
+			)...)
 			currentY += fontSize * LineHeight * 1.2
 
 		case "bullet", "numbering":
@@ -798,161 +823,126 @@ func (mc *MarkdownConverter) populateSlideWithTableLayout(slideId string, slide 
 				prefix = "1. "
 			}
 
-			_, err := mc.client.AddTextBox(
-				mc.presentationId,
+			b.add(addTextBoxRequests(
 				slideId,
+				b.id("tb"),
 				prefix+element.Content,
 				MarginLeft,
 				currentY,
 				SlideWidth-MarginLeft-MarginRight,
 				DefaultFontSize*LineHeight,
-			)
-			if err != nil {
-				return err
-			}
+			)...)
 			currentY += DefaultFontSize * LineHeight
 
 		case "code":
 			// Add code block with Courier New font
-			_, err := mc.client.AddCodeTextBox(
-				mc.presentationId,
+			b.add(addCodeTextBoxRequests(
 				slideId,
+				b.id("code"),
 				element.Content,
 				MarginLeft,
 				currentY,
 				SlideWidth-MarginLeft-MarginRight,
 				100, // Fixed height for code blocks
-			)
-			if err != nil {
-				return err
-			}
+			)...)
 			currentY += 100 + 10
 
 		case "image":
-			// Add image at 50% of slide size
-			imageWidth := SlideWidth * 0.5
-			imageHeight := SlideHeight * 0.5
-			imageX := (SlideWidth - imageWidth) / 2
-
-			_, err := mc.client.AddImage(
-				mc.presentationId,
-				slideId,
-				element.Content,
-				imageX,
-				currentY,
-				imageWidth,
-				imageHeight,
-			)
-			if err != nil {
-				return fmt.Errorf("failed to add image: %w", err)
-			}
-			currentY += imageHeight + 10
-
-			// Add alt text as caption below image if present
-			if element.AltText != "" {
-				captionWidth := imageWidth
-				_, err := mc.client.AddTextBox(
-					mc.presentationId,
-					slideId,
-					element.AltText,
-					imageX,
-					currentY,
-					captionWidth,
-					DefaultFontSize*LineHeight,
-				)
-				if err != nil {
-					return fmt.Errorf("failed to add image caption: %w", err)
-				}
-				currentY += DefaultFontSize*LineHeight + 10
-			}
+			currentY = addMarkdownImage(b, slideId, element, currentY)
 
 		case "table":
-			if len(element.Items) > 0 {
-				rows := len(element.Items)
-				cols := strings.Count(element.Items[0], "|") - 1
-				if cols > 0 {
-					tableWidth := SlideWidth - MarginLeft - MarginRight
-					tableHeight := float64(rows) * 30.0
+			currentY = addMarkdownTable(b, slideId, element, currentY)
+		}
+	}
+}
 
-					resp, err := mc.client.AddTable(
-						mc.presentationId,
-						slideId,
-						rows,
-						cols,
-						MarginLeft,
-						currentY,
-						tableWidth,
-						tableHeight,
-					)
-					if err != nil {
-						return err
-					}
+// addMarkdownImage places an image, and its alt text as a caption, and returns
+// the vertical position the next element should start at.
+func addMarkdownImage(b *slideBatch, slideId string, element MarkdownElement, currentY float64) float64 {
+	// Add image at 50% of slide size
+	imageWidth := SlideWidth * 0.5
+	imageHeight := SlideHeight * 0.5
+	imageX := (SlideWidth - imageWidth) / 2
 
-					// Populate table cells
-					if resp != nil && len(resp.Replies) > 0 && resp.Replies[0].CreateTable != nil {
-						tableId := resp.Replies[0].CreateTable.ObjectId
+	b.add(addImageRequests(slideId, b.id("img"), element.Content, imageX, currentY, imageWidth, imageHeight)...)
+	currentY += imageHeight + 10
 
-						for rowIdx, row := range element.Items {
-							// Split by | and remove empty entries
-							cells := strings.Split(row, "|")
-							cellTexts := []string{}
-							for _, cell := range cells {
-								trimmed := strings.TrimSpace(cell)
-								if trimmed != "" {
-									cellTexts = append(cellTexts, trimmed)
-								}
-							}
+	// Add alt text as caption below image if present
+	if element.AltText != "" {
+		captionWidth := imageWidth
+		b.add(addTextBoxRequests(
+			slideId,
+			b.id("tb"),
+			element.AltText,
+			imageX,
+			currentY,
+			captionWidth,
+			DefaultFontSize*LineHeight,
+		)...)
+		currentY += DefaultFontSize*LineHeight + 10
+	}
 
-							// Insert text into each cell
-							for colIdx, cellText := range cellTexts {
-								if colIdx < cols {
-									_, err := mc.client.InsertTextInTableCell(
-										mc.presentationId,
-										tableId,
-										rowIdx,
-										colIdx,
-										cellText,
-									)
-									if err != nil {
-										// Log error but continue with other cells
-										log.Printf("[WARNING] Failed to insert text in cell [%d,%d]: %v\n", rowIdx, colIdx, err)
-									}
-								}
-							}
-						}
-					}
+	return currentY
+}
 
-					currentY += tableHeight + 10
-				}
+// addMarkdownTable places a table and fills every cell in the same batch, so a
+// 6x4 table costs 25 requests rather than 25 round trips. It returns the
+// vertical position the next element should start at.
+func addMarkdownTable(b *slideBatch, slideId string, element MarkdownElement, currentY float64) float64 {
+	if len(element.Items) == 0 {
+		return currentY
+	}
+
+	rows := len(element.Items)
+	cols := strings.Count(element.Items[0], "|") - 1
+	if cols <= 0 {
+		return currentY
+	}
+
+	tableWidth := SlideWidth - MarginLeft - MarginRight
+	tableHeight := float64(rows) * 30.0
+	tableId := b.id("tbl")
+
+	b.add(addTableRequests(slideId, tableId, rows, cols, MarginLeft, currentY, tableWidth, tableHeight)...)
+
+	// Populate table cells
+	for rowIdx, row := range element.Items {
+		// Split by | and remove empty entries
+		cells := strings.Split(row, "|")
+		cellTexts := []string{}
+		for _, cell := range cells {
+			trimmed := strings.TrimSpace(cell)
+			if trimmed != "" {
+				cellTexts = append(cellTexts, trimmed)
+			}
+		}
+
+		// Insert text into each cell
+		for colIdx, cellText := range cellTexts {
+			if colIdx < cols {
+				b.add(insertTextInTableCellRequests(tableId, rowIdx, colIdx, cellText)...)
 			}
 		}
 	}
 
-	return nil
+	return currentY + tableHeight + 10
 }
 
-func (mc *MarkdownConverter) populateSlide(slideId string, slide MarkdownSlide) error {
+func populateSlide(b *slideBatch, slideId string, slide MarkdownSlide) {
 	// All slides are now blank, so we add text boxes for everything
 	currentY := MarginTop
 
 	// Add title if exists
 	if slide.Title != "" {
-		resp, err := mc.client.AddTextBox(
-			mc.presentationId,
+		b.add(addTextBoxRequests(
 			slideId,
+			b.id("tb"),
 			slide.Title,
 			MarginLeft,
 			currentY,
 			SlideWidth-MarginLeft-MarginRight,
 			TitleFontSize*LineHeight,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to add title '%s': %w", slide.Title, err)
-		}
-		// Log response for debugging
-		if resp == nil || len(resp.Replies) == 0 {
-			return fmt.Errorf("no response for title '%s'", slide.Title)
-		}
+		)...)
 		currentY += TitleFontSize * LineHeight * 1.5
 	}
 
@@ -969,18 +959,15 @@ func (mc *MarkdownConverter) populateSlide(slideId string, slide MarkdownSlide) 
 				fontSize = H3FontSize
 			}
 
-			_, err := mc.client.AddTextBox(
-				mc.presentationId,
+			b.add(addTextBoxRequests(
 				slideId,
+				b.id("tb"),
 				element.Content,
 				MarginLeft,
 				currentY,
 				SlideWidth-MarginLeft-MarginRight,
 				fontSize*LineHeight,
-			)
-			if err != nil {
-				return err
-			}
+			)...)
 			currentY += fontSize * LineHeight * 1.2
 
 		case "bullet", "numbering":
@@ -990,138 +977,37 @@ func (mc *MarkdownConverter) populateSlide(slideId string, slide MarkdownSlide) 
 			}
 			indent := float64(element.Level) * 20.0
 
-			_, err := mc.client.AddTextBox(
-				mc.presentationId,
+			b.add(addTextBoxRequests(
 				slideId,
+				b.id("tb"),
 				prefix+element.Content,
 				MarginLeft+indent,
 				currentY,
 				SlideWidth-MarginLeft-MarginRight-indent,
 				DefaultFontSize*LineHeight,
-			)
-			if err != nil {
-				return err
-			}
+			)...)
 			currentY += DefaultFontSize * LineHeight
 
 		case "code":
 			// Add code block with Courier New font
-			_, err := mc.client.AddCodeTextBox(
-				mc.presentationId,
+			b.add(addCodeTextBoxRequests(
 				slideId,
+				b.id("code"),
 				element.Content,
 				MarginLeft,
 				currentY,
 				SlideWidth-MarginLeft-MarginRight,
 				100, // Fixed height for code blocks
-			)
-			if err != nil {
-				return err
-			}
+			)...)
 			currentY += 100 + 10
 
 		case "image":
-			// Add image at 50% of slide size
-			imageWidth := SlideWidth * 0.5
-			imageHeight := SlideHeight * 0.5
-			imageX := (SlideWidth - imageWidth) / 2
-
-			_, err := mc.client.AddImage(
-				mc.presentationId,
-				slideId,
-				element.Content,
-				imageX,
-				currentY,
-				imageWidth,
-				imageHeight,
-			)
-			if err != nil {
-				return err
-			}
-			currentY += imageHeight + 10
-
-			// Add alt text as caption below image if present
-			if element.AltText != "" {
-				captionWidth := imageWidth
-				_, err := mc.client.AddTextBox(
-					mc.presentationId,
-					slideId,
-					element.AltText,
-					imageX,
-					currentY,
-					captionWidth,
-					DefaultFontSize*LineHeight,
-				)
-				if err != nil {
-					return err
-				}
-				currentY += DefaultFontSize*LineHeight + 10
-			}
+			currentY = addMarkdownImage(b, slideId, element, currentY)
 
 		case "table":
-			if len(element.Items) > 0 {
-				rows := len(element.Items)
-				cols := strings.Count(element.Items[0], "|") - 1
-				if cols > 0 {
-					tableWidth := SlideWidth - MarginLeft - MarginRight
-					tableHeight := float64(rows) * 30.0
-
-					resp, err := mc.client.AddTable(
-						mc.presentationId,
-						slideId,
-						rows,
-						cols,
-						MarginLeft,
-						currentY,
-						tableWidth,
-						tableHeight,
-					)
-					if err != nil {
-						return err
-					}
-
-					// Get the table ID from the response
-					if resp != nil && len(resp.Replies) > 0 && resp.Replies[0].CreateTable != nil {
-						tableId := resp.Replies[0].CreateTable.ObjectId
-
-						// Populate table cells with text
-						for rowIdx, row := range element.Items {
-							// Split by | and remove empty entries
-							cells := strings.Split(row, "|")
-							cellTexts := []string{}
-							for _, cell := range cells {
-								trimmed := strings.TrimSpace(cell)
-								if trimmed != "" {
-									cellTexts = append(cellTexts, trimmed)
-								}
-							}
-
-							// Insert text into each cell
-							for colIdx, cellText := range cellTexts {
-								if colIdx < cols {
-									_, err := mc.client.InsertTextInTableCell(
-										mc.presentationId,
-										tableId,
-										rowIdx,
-										colIdx,
-										cellText,
-									)
-									if err != nil {
-										// Log error but continue with other cells
-										log.Printf("[WARNING] Failed to insert text in cell [%d,%d]: %v\n", rowIdx, colIdx, err)
-									}
-								}
-							}
-						}
-					}
-
-					currentY += tableHeight + 10
-				}
-			}
+			currentY = addMarkdownTable(b, slideId, element, currentY)
 		}
 	}
-
-	return nil
 }
 
 // UpdateSlidesFromMarkdown replaces the deck's contents with the slides
@@ -1160,10 +1046,32 @@ func (mc *MarkdownConverter) UpdateSlidesFromMarkdown(markdown string) error {
 			len(obsoleteSlideIds))
 	}
 
-	for _, slideId := range obsoleteSlideIds {
-		if _, err := mc.client.DeleteSlide(mc.presentationId, slideId); err != nil {
-			return fmt.Errorf("created %d new slides but failed to remove the previous slide %s: %w",
-				len(createdSlideIds), slideId, err)
+	if err := mc.deleteSlidesInBatches(obsoleteSlideIds); err != nil {
+		return fmt.Errorf("created %d new slides but failed to remove the previous ones: %w",
+			len(createdSlideIds), err)
+	}
+
+	return nil
+}
+
+// deleteSlidesInBatches removes slides with as few calls as the request cap
+// allows. Deleting one slide per call would put the update straight back into
+// rate limiting on exactly the decks this batching exists to serve: replacing a
+// 45-slide deck would cost 45 calls to tear the old one down.
+func (mc *MarkdownConverter) deleteSlidesInBatches(slideIds []string) error {
+	for start := 0; start < len(slideIds); start += maxRequestsPerBatch {
+		end := start + maxRequestsPerBatch
+		if end > len(slideIds) {
+			end = len(slideIds)
+		}
+
+		requests := make([]*slides.Request, 0, end-start)
+		for _, slideId := range slideIds[start:end] {
+			requests = append(requests, deleteSlideRequests(slideId)...)
+		}
+
+		if _, err := mc.client.BatchUpdate(mc.presentationId, requests); err != nil {
+			return err
 		}
 	}
 
@@ -1174,10 +1082,12 @@ func (mc *MarkdownConverter) UpdateSlidesFromMarkdown(markdown string) error {
 // best effort: the caller is already returning the error that caused the
 // rollback, and a cleanup failure should not replace it.
 func (mc *MarkdownConverter) removePartialSlides(slideIds []string) {
-	for _, slideId := range slideIds {
-		if _, err := mc.client.DeleteSlide(mc.presentationId, slideId); err != nil {
-			log.Printf("[WARNING] Failed to remove partially built slide %s; it may need deleting by hand: %v\n",
-				slideId, err)
-		}
+	if len(slideIds) == 0 {
+		return
+	}
+
+	if err := mc.deleteSlidesInBatches(slideIds); err != nil {
+		log.Printf("[WARNING] Failed to remove %d partially built slide(s); they may need deleting by hand: %v\n",
+			len(slideIds), err)
 	}
 }

--- a/slides/markdown.go
+++ b/slides/markdown.go
@@ -397,30 +397,50 @@ func (b *slideBatch) addSlide(slideId string) {
 }
 
 func (b *slideBatch) flush() error {
-	if len(b.pending) == 0 {
+	return b.flushChunk(len(b.pending))
+}
+
+// flushChunk sends the first n pending requests and keeps the rest.
+//
+// Every slide's createSlide request is appended before the rest of that slide,
+// and a chunk is only cut once the buffer has reached the cap, so the cut is
+// always past the createSlide of every slide represented in it. That makes it
+// safe to treat all pending slides as created once the chunk lands.
+func (b *slideBatch) flushChunk(n int) error {
+	if n > len(b.pending) {
+		n = len(b.pending)
+	}
+	if n == 0 {
 		return nil
 	}
 
-	pending := b.pending
-	b.pending = nil
-	pendingSlideIds := b.pendingSlideIds
-	b.pendingSlideIds = nil
-
-	if _, err := b.client.BatchUpdate(b.presentationId, pending); err != nil {
+	if _, err := b.client.BatchUpdate(b.presentationId, b.pending[:n]); err != nil {
 		return err
 	}
 
-	b.createdSlideIds = append(b.createdSlideIds, pendingSlideIds...)
+	b.pending = b.pending[n:]
+	b.createdSlideIds = append(b.createdSlideIds, b.pendingSlideIds...)
+	b.pendingSlideIds = nil
+
 	return nil
 }
 
-// flushIfFull sends the pending requests once they reach the cap. It is called
-// at slide boundaries so a chunk never splits a slide in half.
+// flushIfFull sends full chunks while the buffer is at or over the cap, so no
+// single BatchUpdate ever carries more than maxRequestsPerBatch requests.
+//
+// Checking only at slide boundaries is not enough on its own: a slide appended
+// onto an almost-full buffer, or a single slide with a large table, would
+// otherwise push one batch past the cap. Chunking mid-slide is safe because the
+// object IDs are ours, so a later chunk addresses objects an earlier one
+// created.
 func (b *slideBatch) flushIfFull() error {
-	if len(b.pending) < maxRequestsPerBatch {
-		return nil
+	for len(b.pending) >= maxRequestsPerBatch {
+		if err := b.flushChunk(maxRequestsPerBatch); err != nil {
+			return err
+		}
 	}
-	return b.flush()
+
+	return nil
 }
 
 // layoutPlaceholders holds a layout's own placeholder element IDs.
@@ -624,13 +644,18 @@ func (mc *MarkdownConverter) appendSlidesFromMarkdown(markdown string) ([]string
 			populateSlide(batch, slideId, slide)
 		}
 
+		// The rejected request can belong to any slide in the batch, not just
+		// the one that filled it, so the error names the batch rather than
+		// pointing at a slide that may be blameless.
 		if err := batch.flushIfFull(); err != nil {
-			return batch.createdSlideIds, fmt.Errorf("failed to create slide %d: %w", i+1, err)
+			return batch.createdSlideIds, fmt.Errorf(
+				"a batch of requests covering slides up to %d was rejected: %w", i+1, err)
 		}
 	}
 
 	if err := batch.flush(); err != nil {
-		return batch.createdSlideIds, fmt.Errorf("failed to create %d slides: %w", len(parsedSlides), err)
+		return batch.createdSlideIds, fmt.Errorf(
+			"the final batch of requests for %d slides was rejected: %w", len(parsedSlides), err)
 	}
 
 	return batch.createdSlideIds, nil

--- a/slides/update_atomicity_test.go
+++ b/slides/update_atomicity_test.go
@@ -87,6 +87,9 @@ type fakeSlidesAPI struct {
 	slides   []*slides.Page // current deck, in order
 	requests []string       // request kinds in the order they were issued
 	batches  int            // batchUpdate calls, successful or not
+	// batchSizes records how many requests each batchUpdate carried, so tests
+	// can check the per-batch cap is actually enforced
+	batchSizes []int
 	// text holds what landed in each shape, keyed by object ID and, for table
 	// cells, by "tableId[row,col]".
 	text map[string]string
@@ -130,6 +133,7 @@ func (f *fakeSlidesAPI) handleBatchUpdate(req *http.Request) (*http.Response, er
 	}
 
 	f.batches++
+	f.batchSizes = append(f.batchSizes, len(parsed.Requests))
 
 	// batchUpdate is atomic: a batch that fails partway leaves nothing behind,
 	// so the fake has to undo whatever this batch had already applied.

--- a/slides/update_atomicity_test.go
+++ b/slides/update_atomicity_test.go
@@ -3,7 +3,9 @@ package slides
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -13,13 +15,85 @@ import (
 	"google.golang.org/api/slides/v1"
 )
 
+// fakeLayout describes one of the layouts the fake presentation offers,
+// including the placeholders that layout produces. Slides created from a layout
+// may only map the placeholders it actually defines, which is what forces the
+// converter to read them from the layout rather than guess.
+type fakeLayout struct {
+	objectId     string
+	name         string
+	placeholders []fakePlaceholder
+}
+
+type fakePlaceholder struct {
+	objectId string
+	kind     string
+}
+
+var fakeLayouts = []fakeLayout{
+	{objectId: "layout-title-body", name: "TITLE_AND_BODY", placeholders: []fakePlaceholder{
+		{objectId: "layout-title-body-title", kind: "TITLE"},
+		{objectId: "layout-title-body-body", kind: "BODY"},
+	}},
+	{objectId: "layout-title", name: "TITLE", placeholders: []fakePlaceholder{
+		// Themes differ here; CENTERED_TITLE + SUBTITLE is the common shape.
+		{objectId: "layout-title-title", kind: "CENTERED_TITLE"},
+		{objectId: "layout-title-sub", kind: "SUBTITLE"},
+	}},
+	{objectId: "layout-title-only", name: "TITLE_ONLY", placeholders: []fakePlaceholder{
+		{objectId: "layout-title-only-title", kind: "TITLE"},
+	}},
+}
+
+func layoutPages() []*slides.Page {
+	pages := make([]*slides.Page, 0, len(fakeLayouts))
+	for _, layout := range fakeLayouts {
+		elements := make([]*slides.PageElement, 0, len(layout.placeholders))
+		for _, ph := range layout.placeholders {
+			elements = append(elements, &slides.PageElement{
+				ObjectId: ph.objectId,
+				Shape:    &slides.Shape{Placeholder: &slides.Placeholder{Type: ph.kind}},
+			})
+		}
+		pages = append(pages, &slides.Page{
+			ObjectId:         layout.objectId,
+			LayoutProperties: &slides.LayoutProperties{Name: layout.name},
+			PageElements:     elements,
+		})
+	}
+	return pages
+}
+
+func findFakeLayout(objectId string) (fakeLayout, bool) {
+	for _, layout := range fakeLayouts {
+		if layout.objectId == objectId {
+			return layout, true
+		}
+	}
+	return fakeLayout{}, false
+}
+
+// textStyling records an UpdateTextStyle the fake accepted.
+type textStyling struct {
+	objectId   string
+	fontFamily string
+}
+
 // fakeSlidesAPI is a minimal stand-in for the two Slides endpoints this package
 // uses: presentations.get and presentations.batchUpdate. It keeps enough state
 // that a deck can actually be built against it, and records the order of the
 // requests so tests can assert on sequencing.
 type fakeSlidesAPI struct {
-	slides     []*slides.Page // current deck, in order
-	requests   []string       // request kinds in the order they were issued
+	slides   []*slides.Page // current deck, in order
+	requests []string       // request kinds in the order they were issued
+	batches  int            // batchUpdate calls, successful or not
+	// text holds what landed in each shape, keyed by object ID and, for table
+	// cells, by "tableId[row,col]".
+	text map[string]string
+	// objectIds are the IDs the caller assigned, in the order they were used
+	objectIds  []string
+	tableIds   []string
+	styled     []textStyling
 	nextID     int
 	failCreate bool // fail any batch containing a createSlide
 	// failCreateAfter, when non-zero, lets that many slides be created before
@@ -40,11 +114,7 @@ func (f *fakeSlidesAPI) handleGet() (*http.Response, error) {
 	return jsonResponse(http.StatusOK, &slides.Presentation{
 		PresentationId: "test-presentation",
 		Slides:         f.slides,
-		Layouts: []*slides.Page{
-			{ObjectId: "layout-title-body", LayoutProperties: &slides.LayoutProperties{Name: "TITLE_AND_BODY"}},
-			{ObjectId: "layout-title", LayoutProperties: &slides.LayoutProperties{Name: "TITLE"}},
-			{ObjectId: "layout-title-only", LayoutProperties: &slides.LayoutProperties{Name: "TITLE_ONLY"}},
-		},
+		Layouts:        layoutPages(),
 	})
 }
 
@@ -59,30 +129,88 @@ func (f *fakeSlidesAPI) handleBatchUpdate(req *http.Request) (*http.Response, er
 		return nil, err
 	}
 
+	f.batches++
+
+	// batchUpdate is atomic: a batch that fails partway leaves nothing behind,
+	// so the fake has to undo whatever this batch had already applied.
+	slidesBefore := append([]*slides.Page(nil), f.slides...)
+	textBefore := maps.Clone(f.text)
+	objectIdsBefore := append([]string(nil), f.objectIds...)
+	tableIdsBefore := append([]string(nil), f.tableIds...)
+	styledBefore := append([]textStyling(nil), f.styled...)
+	fail := func(status int, message string) (*http.Response, error) {
+		f.slides = slidesBefore
+		f.text = textBefore
+		f.objectIds = objectIdsBefore
+		f.tableIds = tableIdsBefore
+		f.styled = styledBefore
+		return jsonResponse(status,
+			map[string]any{"error": map[string]any{"code": status, "message": message}})
+	}
+
 	replies := make([]*slides.Response, 0, len(parsed.Requests))
 	for _, r := range parsed.Requests {
 		switch {
 		case r.CreateSlide != nil:
 			f.requests = append(f.requests, "createSlide")
 			if f.failCreateAfter > 0 && f.count("createSlide") > f.failCreateAfter {
-				return jsonResponse(http.StatusInternalServerError,
-					map[string]any{"error": map[string]any{"code": 500, "message": "boom"}})
+				return fail(http.StatusInternalServerError, "boom")
 			}
 			if f.failCreate {
-				return jsonResponse(http.StatusInternalServerError,
-					map[string]any{"error": map[string]any{"code": 500, "message": "boom"}})
+				return fail(http.StatusInternalServerError, "boom")
 			}
-			replies = append(replies, &slides.Response{CreateSlide: &slides.CreateSlideResponse{
-				ObjectId: f.addSlide(),
-			}})
+			id, err := f.addSlideFromRequest(r.CreateSlide)
+			if err != nil {
+				return fail(http.StatusBadRequest, err.Error())
+			}
+			replies = append(replies, &slides.Response{CreateSlide: &slides.CreateSlideResponse{ObjectId: id}})
 
 		case r.DeleteObject != nil:
 			f.requests = append(f.requests, "deleteObject")
 			f.removeSlide(r.DeleteObject.ObjectId)
 			replies = append(replies, &slides.Response{})
 
+		case r.CreateTable != nil:
+			f.requests = append(f.requests, "createTable")
+			f.recordObjectId(r.CreateTable.ObjectId)
+			f.tableIds = append(f.tableIds, r.CreateTable.ObjectId)
+			replies = append(replies, &slides.Response{CreateTable: &slides.CreateTableResponse{
+				ObjectId: r.CreateTable.ObjectId,
+			}})
+
+		case r.CreateImage != nil:
+			f.requests = append(f.requests, "createImage")
+			f.recordObjectId(r.CreateImage.ObjectId)
+			replies = append(replies, &slides.Response{CreateImage: &slides.CreateImageResponse{
+				ObjectId: r.CreateImage.ObjectId,
+			}})
+
+		case r.CreateShape != nil:
+			f.requests = append(f.requests, "createShape")
+			f.recordObjectId(r.CreateShape.ObjectId)
+			replies = append(replies, &slides.Response{CreateShape: &slides.CreateShapeResponse{
+				ObjectId: r.CreateShape.ObjectId,
+			}})
+
+		case r.InsertText != nil:
+			f.requests = append(f.requests, "insertText")
+			f.recordText(r.InsertText)
+			replies = append(replies, &slides.Response{})
+
+		case r.DeleteText != nil:
+			f.requests = append(f.requests, "deleteText")
+			replies = append(replies, &slides.Response{})
+
+		case r.UpdateTextStyle != nil:
+			f.requests = append(f.requests, "updateTextStyle")
+			styling := textStyling{objectId: r.UpdateTextStyle.ObjectId}
+			if r.UpdateTextStyle.Style != nil {
+				styling.fontFamily = r.UpdateTextStyle.Style.FontFamily
+			}
+			f.styled = append(f.styled, styling)
+			replies = append(replies, &slides.Response{})
+
 		default:
-			// insertText, deleteText, formatting and so on: accepted as-is
 			f.requests = append(f.requests, "other")
 			replies = append(replies, &slides.Response{})
 		}
@@ -91,9 +219,79 @@ func (f *fakeSlidesAPI) handleBatchUpdate(req *http.Request) (*http.Response, er
 	return jsonResponse(http.StatusOK, &slides.BatchUpdatePresentationResponse{Replies: replies})
 }
 
-// addSlide appends a slide carrying the title and body placeholders the
-// populate step looks for, and returns its ID.
-func (f *fakeSlidesAPI) addSlide() string {
+func (f *fakeSlidesAPI) recordObjectId(id string) {
+	if id != "" {
+		f.objectIds = append(f.objectIds, id)
+	}
+}
+
+func (f *fakeSlidesAPI) recordText(req *slides.InsertTextRequest) {
+	if f.text == nil {
+		f.text = map[string]string{}
+	}
+	key := req.ObjectId
+	if req.CellLocation != nil {
+		key = fmt.Sprintf("%s[%d,%d]", req.ObjectId, req.CellLocation.RowIndex, req.CellLocation.ColumnIndex)
+	}
+	f.text[key] = req.Text
+}
+
+// addSlideFromRequest honours the caller-supplied object ID and placeholder
+// mappings, rejecting a mapping the layout does not define exactly as the real
+// API does.
+func (f *fakeSlidesAPI) addSlideFromRequest(req *slides.CreateSlideRequest) (string, error) {
+	id := req.ObjectId
+	if id == "" {
+		f.nextID++
+		id = "slide-" + strconv.Itoa(f.nextID)
+	}
+	f.recordObjectId(req.ObjectId)
+
+	var layout fakeLayout
+	if req.SlideLayoutReference != nil {
+		found, ok := findFakeLayout(req.SlideLayoutReference.LayoutId)
+		if !ok {
+			return "", fmt.Errorf("unknown layout %q", req.SlideLayoutReference.LayoutId)
+		}
+		layout = found
+	}
+
+	mapped := map[string]string{}
+	for _, m := range req.PlaceholderIdMappings {
+		kind := ""
+		for _, ph := range layout.placeholders {
+			if ph.objectId == m.LayoutPlaceholderObjectId {
+				kind = ph.kind
+				break
+			}
+		}
+		if kind == "" {
+			return "", fmt.Errorf("layout %q has no placeholder %q", layout.name, m.LayoutPlaceholderObjectId)
+		}
+		f.recordObjectId(m.ObjectId)
+		mapped[m.LayoutPlaceholderObjectId] = m.ObjectId
+	}
+
+	elements := make([]*slides.PageElement, 0, len(layout.placeholders))
+	for _, ph := range layout.placeholders {
+		objectId, ok := mapped[ph.objectId]
+		if !ok {
+			objectId = id + "-" + strings.ToLower(ph.kind)
+		}
+		elements = append(elements, &slides.PageElement{
+			ObjectId: objectId,
+			Shape:    &slides.Shape{Placeholder: &slides.Placeholder{Type: ph.kind}},
+		})
+	}
+
+	f.slides = append(f.slides, &slides.Page{ObjectId: id, PageElements: elements})
+
+	return id, nil
+}
+
+// seedSlide adds a pre-existing slide to the deck, standing in for one the user
+// already had.
+func (f *fakeSlidesAPI) seedSlide() string {
 	f.nextID++
 	id := "slide-" + strconv.Itoa(f.nextID)
 
@@ -106,6 +304,20 @@ func (f *fakeSlidesAPI) addSlide() string {
 	})
 
 	return id
+}
+
+// placeholderText returns the text inserted into the placeholder of the given
+// kind on the nth slide (0-based) of the deck.
+func (f *fakeSlidesAPI) placeholderText(slideIndex int, kind string) string {
+	if slideIndex >= len(f.slides) {
+		return ""
+	}
+	for _, element := range f.slides[slideIndex].PageElements {
+		if element.Shape != nil && element.Shape.Placeholder != nil && element.Shape.Placeholder.Type == kind {
+			return f.text[element.ObjectId]
+		}
+	}
+	return ""
 }
 
 func (f *fakeSlidesAPI) removeSlide(id string) {
@@ -156,10 +368,11 @@ func newFakeConverter(t *testing.T, existingSlides int) (*MarkdownConverter, *fa
 
 	fake := &fakeSlidesAPI{}
 	for i := 0; i < existingSlides; i++ {
-		fake.addSlide()
+		fake.seedSlide()
 	}
 	// Requests made while seeding are setup, not part of what we assert on
 	fake.requests = nil
+	fake.batches = 0
 
 	client, err := NewClient(context.Background(), &http.Client{Transport: fake})
 	if err != nil {
@@ -234,16 +447,26 @@ func TestUpdateKeepsExistingSlidesWhenCreationFails(t *testing.T) {
 }
 
 // TestUpdateRemovesPartiallyBuiltSlidesOnFailure covers a rebuild that dies
-// after some slides already exist. Keeping the original deck is not enough on
-// its own: the half-built replacement has to go too, or the user is left with
-// both decks interleaved and every retry strands another run of orphans.
+// after some slides already exist. A single batch is atomic, so the only way to
+// strand slides now is to fail on a later chunk: the earlier chunks are already
+// committed. Keeping the original deck is not enough on its own — the
+// half-built replacement has to go too, or the user is left with both decks
+// interleaved and every retry strands another run of orphans.
 func TestUpdateRemovesPartiallyBuiltSlidesOnFailure(t *testing.T) {
 	mc, fake := newFakeConverter(t, 3)
 	before := fake.slideIDs()
-	fake.failCreateAfter = 1 // first slide succeeds, the second does not
+
+	// Force one slide per chunk so the failure lands after a committed chunk
+	withMaxRequestsPerBatch(t, 1)
+	fake.failCreateAfter = 1 // the first chunk succeeds, the second does not
 
 	if err := mc.UpdateSlidesFromMarkdown(twoSlideMarkdown); err == nil {
 		t.Fatal("expected an error when the rebuild fails partway")
+	}
+
+	if fake.batches < 2 {
+		t.Fatalf("the deck was sent in %d batches; the test only means anything "+
+			"if the failure lands after an earlier chunk committed", fake.batches)
 	}
 
 	if got := fake.slideIDs(); len(got) != len(before) {
@@ -313,6 +536,16 @@ func TestBatchUpdateRetriesAreNotNested(t *testing.T) {
 		t.Errorf("BatchUpdate made %d attempts, want %d; nested retries multiply the budget "+
 			"and hammer an API that is already rate limiting", attempts, maxRetries)
 	}
+}
+
+// withMaxRequestsPerBatch lowers the flush threshold for the duration of a
+// test, so chunking can be exercised without building an enormous deck.
+func withMaxRequestsPerBatch(t *testing.T, n int) {
+	t.Helper()
+
+	restore := maxRequestsPerBatch
+	maxRequestsPerBatch = n
+	t.Cleanup(func() { maxRequestsPerBatch = restore })
 }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)


### PR DESCRIPTION
## Summary

Closes the rate limiting reported in #5. Follows #17, and implements the design proposed there.

Markdown-to-slides cost 6–9 sequential API calls per slide, including a full `GetPresentation` per slide just to locate two placeholder IDs. A 45-slide deck was ~300 calls against a 60/min quota.

Measured through the test fake, replacing a 45-slide deck:

| | batchUpdate calls | GetPresentation calls |
| --- | --- | --- |
| Before | ~300 | 45 |
| After | **2** | **2** |

Constant in the size of the deck being replaced.

## How

`CreateSlideRequest.PlaceholderIdMappings` names the layout's placeholders at creation time, so later requests in the same batch can fill them. That is what removes the per-slide fetch. Tables and images take caller-supplied object IDs, so their contents — including every table cell — are populated in the same batch; a 6×4 table goes from 24 calls to 24 requests.

**The one real hazard** is that the API rejects a mapping for a placeholder the layout does not define, while the old code adapted by inspecting each created slide (a title may be `TITLE` or `CENTERED_TITLE`, and some layouts have no body). So the placeholders are read from `presentation.Layouts[]` once, up front, and mappings are emitted only for slots the layout actually has.

Client write methods are split into pure request builders plus the existing senders. **Every exported signature is unchanged**, verified by diffing them against master, so the standalone `slides_*` tools behave exactly as before.

Requests flush every 500 to stay within the API's per-batch limits. The rollback added in #17 still covers a failure between chunks.

## Deleting the old deck is batched too

Worth calling out, because it was nearly missed. Building the new slides in one batch is only half of an update. Tearing the old deck down one slide per call left a 45-slide replacement at **46** calls — most of the benefit gone on exactly the decks this exists to serve. `deleteSlidesInBatches` handles both the replacement and the rollback path.

This was caught by measuring `UpdateSlidesFromMarkdown` with a realistic existing deck; the original call-count test measured construction alone, starting from an empty presentation, so it read 1 batch and looked fine.

## Testing

The stateful fake from #17 was extended to model layouts and their placeholders, to reject mappings a layout does not define, to record inserted text, and — importantly — to apply batches **atomically**, since the real API does. The previous fake kept slides added earlier in a failed batch, which would have let tests assert behaviour the real API does not have.

Added:

- `TestDeckIsBuiltInOneBatch` — a 45-slide build is ≤2 batches and exactly 1 fetch
- `TestUpdateOfExistingDeckStaysWithinAFewCalls` — the full replace path, against decks of 1 and 45 slides
- `TestLayoutPathsProduceTheExpectedContent` — TITLE, TITLE_AND_BODY, TITLE_ONLY with a table, with an image, and code blocks all still land the same text in the same placeholders
- `TestBuildChunksLargeDecks`, `TestGeneratedObjectIdsAreValid`, `TestFailedBatchReportsNoCreatedSlides`, `TestBuildEmitsNoDeleteTextForFreshSlides`

Every assertion was checked against deliberately broken code rather than assumed meaningful. Two examples:

```
# deletion left unbatched
replacing a 45-slide deck took 46 batchUpdate calls, want at most 2

# body placeholder binding removed
body placeholder holds "", want "• one\n• two"
```

`go build`, `go test ./...`, `go vet ./...` and `gofmt -l` are clean.

## Not included

Diff-based updates. As argued in the design, batching delivers two of #5's three benefits — speed and call count — while the third, preserving manual edits made in the Slides UI, needs per-slide hashes with nowhere natural to store them, and can only ever guarantee "slides whose markdown did not change are not touched". Worth re-evaluating whether #5 still wants it now that the quota pressure is gone.